### PR TITLE
Script to run angel-player for development

### DIFF
--- a/run-angel-player
+++ b/run-angel-player
@@ -1,0 +1,11 @@
+#!/bin/bash -xe
+#
+# Runs a development version of angel-player using a copy of xulrunner from the
+# build directory
+#
+
+[ -x "./build/angel-player/angel-player.app/xul-lin64/xulrunner" ] || {
+	./build.sh
+}
+
+./build/angel-player/angel-player.app/xul-lin64/xulrunner angel-player/src/application.ini -jsconsole -purgecaches


### PR DESCRIPTION
Uses the copy of xulrunner from the build directory to run the files
currently in the source tree.
