### PR TITLE
Reduce the number of bits in the "sample" field

### DIFF
--- a/doc/smartsensor.txt
+++ b/doc/smartsensor.txt
@@ -100,14 +100,14 @@ The following range of type bytes are allocated:
 
 Several examples of maintainance frames follow:
 
-Type 0xAA, no payload:
-0x00 0xAA 0x03
+Type 0xDD, no payload:
+0x00 0xDD 0x03
 
-Type 0xAA, payload of length 1 containing "0xDD":
-0x00 0xAA 0x05 0x01 0xDD
+Type 0xDD, payload of length 1 containing "0xDD":
+0x00 0xDD 0x05 0x01 0xDD
 
-Type 0xAA, payload of length 2 containng "0x00 0xEE":
-0x00 0xAA 0x06 0x01 0x01 0xEE
+Type 0xDD, payload of length 2 containng "0x00 0xEE":
+0x00 0xDD 0x06 0x01 0x01 0xEE
 
 Maintainance frames do not contain link layer CRCs, but CRCs may (will likely)
 be implemented by higher layers of the protocol.
@@ -189,17 +189,18 @@ bytes (96 bytes) and 4 bytes (40 us) of timing slop and/or reserved for future
 expansion.
 
 At the beginning of each subchunk, the master sends the following header:
-    |-------------------------------------------------------------------------------------|
-    | 0x00 | has payload  sample#  subchunk# | <in-band signalling>  <length> | <payload> |
-    |-------------------------------------------------------------------------------------|
+    |---------------------------------------------------------------------------------------|
+    | 0x00 | 0 has payload  sample#  subchunk# | <in-band signalling>  <length> | <payload> |
+    |---------------------------------------------------------------------------------------|
 
 Note that most of this header is not COBS-encoded. The second byte contains a
-flag that is set to 1 iff there is a payload present after the
-subchunk header, the current sample number (mod 8) in bits 4-6 (0-indexed),
-and the current frame number in bits 0-3 (1-indexed). Note that this can never
-result in a value of 0. Iff the "has payload" flag is set to 1, bit0-6 of the
-length byte contains a single byte in the range [1,13] containing the length of
-the in-band signalling payload. The payload (if present) is COBS-encoded.
+0 bit in bit7, a flag in bit6 that is set to 1 iff there is a payload present
+after the subchunk header, the current sample number (mod 4) in bits 4-5
+(0-indexed), and the current frame number in bits 0-3 (1-indexed). Note that
+this can never result in a value of 0. Iff the "has payload" flag is set to 1,
+bit0-6 of the length byte contains a single byte in the range [1,13] containing
+the length of the in-band signalling payload. The payload (if present) is
+COBS-encoded.
 
 The optional payload attached to a subchunk can be either some type of
 in-band signalling or commands to an actuator. The bit7 of the length must be


### PR DESCRIPTION
Previously, the byte range for active mode packet second bytes
could overlap with the range used for maintainance types.
By reducing the range of the "sample" bitfield, this overlap is
avoided. One problem with this is that it makes "One subchunk ever
n samples" even tricker than before, but this a) can be worked
around and b) will not be supported initially.
