### PR TITLE
Fallback to remote debugging port on 6001.

### DIFF
--- a/angel-player/src/chrome/content/debug.js
+++ b/angel-player/src/chrome/content/debug.js
@@ -1,5 +1,7 @@
 Components.utils.import('resource://gre/modules/devtools/dbg-server.jsm');
 Components.utils.import("resource://gre/modules/Services.jsm");
+const console =
+  Components.utils.import("resource://gre/modules/devtools/Console.jsm").console;
 
 var EXPORTED_SYMBOLS = ["debugModule"];
 
@@ -32,7 +34,13 @@ debugModule.init = function() {
       DebuggerServer.addGlobalActor(DebuggerServer.StyleEditorActor,
         "styleEditorActor");
     }
-    DebuggerServer.openListener(6000);
+    try {
+      DebuggerServer.openListener(6000);
+    } catch (_) {
+      console.log("Failed to launch DebuggerServer on port 6000, " +
+                  "attempting to use port 6001");
+      DebuggerServer.openListener(6001);
+    }
 };
 
 debugModule.isDebugEnabled = function() {

--- a/angel-player/src/chrome/content/globalinit.js
+++ b/angel-player/src/chrome/content/globalinit.js
@@ -1,5 +1,5 @@
 Components.utils.import("chrome://angel-player/content/debug.js");
 Components.utils.import("chrome://angel-player/content/superglobals.js");
 
-debugModule.init();
 superGlobals.xulMainWindow = window;
+debugModule.init();


### PR DESCRIPTION
This is necessary if a different version of Firefox is listening for
remote debugging connections on port 6000.

Also reorder the statements in globalinit.js, so that if another
exception is thrown, super-reload still works.
