### PR TITLE
Move non-commonjs code into a module

### DIFF
--- a/angel-player/src/chrome/content/common/console.js
+++ b/angel-player/src/chrome/content/common/console.js
@@ -1,0 +1,10 @@
+/* jshint globalstrict: true */
+"use strict";
+
+const { Cu, Cc, Ci } = require("chrome");
+
+const console =
+    Cu.import("resource://gre/modules/devtools/Console.jsm").console;
+
+//TODO(nikita): Are their more functions in the console?
+exports.log = console.log;

--- a/angel-player/src/chrome/content/common/moz_utils.js
+++ b/angel-player/src/chrome/content/common/moz_utils.js
@@ -1,0 +1,25 @@
+/* jshint globalstrict: true */
+"use strict";
+
+/*
+ * TODO(nikita): comment on what this file does
+ *
+ *
+ */
+
+const { Cu, Cc, Ci } = require("chrome");
+
+// -- Debug module
+// TODO(nikita): expose the mozilla preferences system instead?
+let debugModule =
+    Cu.import("chrome://angel-player/content/debug.js").debugModule;
+exports.isDebugEnabled = debugModule.isDebugEnabled;
+exports.toggleDebug = debugModule.toggleDebug;
+
+// -- Application
+const appStartup =
+    Cc["@mozilla.org/toolkit/app-startup;1"].getService(Ci.nsIAppStartup);
+
+exports.quit_application = function() {
+    appStartup.quit(appStartup.eForceQuit);
+};

--- a/angel-player/src/chrome/content/main-ui/ui.js
+++ b/angel-player/src/chrome/content/main-ui/ui.js
@@ -7,9 +7,7 @@ let $;
 
 let currentSelectedTab = -1;
 
-const { Cu } = require("chrome");
-let debugModule =
-    Cu.import("chrome://angel-player/content/debug.js").debugModule;
+let moz_utils = require("tenshi/common/moz_utils");
 
 // Different ways to arrange the divs to suit different environments. Contains
 // relative flexbox sizes for each element.
@@ -122,7 +120,7 @@ var ENVIRONMENTS = [
 // Useful for prototyping components on their own page, since this can't be done
 // in a browser
 // TODO(rqou): Toggling doesn't update the menu; you need to reload.
-if (debugModule.isDebugEnabled()) {
+if (moz_utils.isDebugEnabled()) {
   ENVIRONMENTS.push({
         text: "Stargate Network",
         image: 'chrome://angel-player/content/main-ui/assets/stargate.png',

--- a/angel-player/src/chrome/content/test/main-commonjs.js
+++ b/angel-player/src/chrome/content/test/main-commonjs.js
@@ -1,10 +1,7 @@
 const url = require ('jetpack/sdk/url');
 const file = require('jetpack/sdk/io/file');
-const { Cu, Cc, Ci } = require('chrome');
-const console =
-    Cu.import("resource://gre/modules/devtools/Console.jsm").console;
-const appStartup =
-    Cc["@mozilla.org/toolkit/app-startup;1"].getService(Ci.nsIAppStartup);
+const console = require('tenshi/common/console');
+const moz_utils = require('tenshi/common/moz_utils');
 
 const TEST_DIR = 'chrome://angel-player/content/test/tests';
 
@@ -47,5 +44,5 @@ exports.onLoad = function(window) {
     }
 
     // Quit
-    appStartup.quit(appStartup.eForceQuit);
+    moz_utils.quit_application();
 };


### PR DESCRIPTION
Non-commonjs code should be restricted to hardware-related modules, and
a minimal number of utility modules.
