### PR TITLE
Refactor runtime libraries into two phases; Change game library

### DIFF
--- a/vm/lua/tenshi-runtime/src/lua/actuators.lua
+++ b/vm/lua/tenshi-runtime/src/lua/actuators.lua
@@ -21,16 +21,7 @@ local actuators = {}
 -- actuator (allowing students to bypass the messaging API).
 
 actuators.metatable = {
-    __index = function(t, k)
-        -- There is a problem here where we get loaded before mboxlib
-        -- and it is hard to refactor it to be otherwise. Therefore we use
-        -- this hack solution where as soon as this function gets called, we
-        -- replace ourselves with the actual mboxlib metatable.
-        local mboxlib_meta =
-            __runtimeinternal.get_registry()['tenshi.mboxlib.metatable']
-        actuators.metatable.__index = mboxlib_meta
-        return t[k]
-    end,
+    __index = __runtimeinternal.get_registry()['tenshi.mboxlib.metatable'],
     __newindex = function(t, k, v)
         if k == 'value' then
             t:send({v})

--- a/vm/lua/tenshi-runtime/src/lua/game.lua
+++ b/vm/lua/tenshi-runtime/src/lua/game.lua
@@ -17,7 +17,12 @@
 
 local game = {}
 
-game.gamestate = get_device('forseti-gamestate')
-game.color = get_device('forseti-color')
+function game.gamestate()
+    return get_device('forseti-gamestate')
+end
+
+function game.color()
+    return get_device('forseti-color')
+end
 
 return game

--- a/vm/lua/tenshi-runtime/src/test_program.c
+++ b/vm/lua/tenshi-runtime/src/test_program.c
@@ -24,6 +24,7 @@
 // Dummy get_device, just takes the id and stores it
 const char *hax_dev_sensor = "stestsensor";
 const char *hax_dev_actuator = "atestactuator";
+const char *hax_dev_gamestate = "forseti-gamestate";
 static int get_device(lua_State *L) {
   size_t id_len;
   const char *id = lua_tolstring(L, -1, &id_len);
@@ -34,6 +35,8 @@ static int get_device(lua_State *L) {
     lua_pushlightuserdata(L, hax_dev_sensor);
   } else if (strcmp(id, hax_dev_actuator) == 0) {
     lua_pushlightuserdata(L, hax_dev_actuator);
+  } else if (strcmp(id, hax_dev_gamestate) == 0) {
+    lua_pushlightuserdata(L, hax_dev_gamestate);
   } else {
     lua_pushnil(L);
   }
@@ -55,17 +58,22 @@ static int query_dev_info(lua_State *L) {
   lua_pop(L, 2);
 
   if (strcmp(query_type, "type") == 0) {
-    // Are we a sensor or an actuator? In this test program, if id[0] is 's' we
-    // are a sensor. Otherwise it's an actuator.
-    if (dev[0] == 's') {
+    // Are we a sensor or an actuator? In this test program, if id[0] is 's'
+    // or 'f' (for forseti-*) we are a sensor. Otherwise it's an actuator.
+    if (dev[0] == 's' || dev[0] == 'f') {
       lua_pushstring(L, "sensor");
     } else {
       lua_pushstring(L, "actuator");
     }
   } else if (strcmp(query_type, "dev") == 0) {
     // What is our device type? In this test program, it is id[1] to the first
-    // embedded null or the end.
-    lua_pushstring(L, dev + 1);
+    // embedded null or the end if it isn't f*
+    if (dev[0] != 'f') {
+      lua_pushstring(L, dev + 1);
+    } else {
+      // We assume it starts with forseti-
+      lua_pushstring(L, dev + 8);
+    }
   } else {
     // Not supported
     lua_pushnil(L);
@@ -92,12 +100,20 @@ static int set_testactuator_val(lua_State *L) {
   return 0;
 }
 
+static int get_gamestate_val(lua_State *L) {
+  lua_pop(L, 1);
+  lua_pushstring(L, "selftest");
+
+  return 1;
+}
+
 static const luaL_Reg testprogram_runtimeentries[] = {
   {"get_device", get_device},
   {"del_device", del_device},
   {"query_dev_info", query_dev_info},
   {"get_testsensor_val", get_testsensor_val},
   {"set_testactuator_val", set_testactuator_val},
+  {"get_gamestate_val", get_gamestate_val},
   {NULL, NULL}
 };
 
@@ -115,10 +131,13 @@ int main(int argc, char **argv) {
     "actuator = get_device('atestactuator')\n"
     "sensor_sampled = triggers.sampled(sensor)\n"
     "\n"
+    "gamestate = game.gamestate()\n"
+    "\n"
     "while true do\n"
     "    local val = sensor_sampled:recv()\n"
     "    print('sensor is ' .. tostring(val))\n"
     "    actuator:send({val})\n"
+    "    print('gamestate is ' .. tostring(gamestate.value))\n"
     "end";
 
   TenshiActorState a;
@@ -128,6 +147,9 @@ int main(int argc, char **argv) {
 
   ret = ActorSetRunnable(a, 1);
   printf("ActorSetRunnable: %d\n", ret);
+
+  ret = TenshiFlagSensor(s, hax_dev_gamestate);
+  printf("TenshiFlagSensor: %d\n", ret);
 
   int i = 0;
 


### PR DESCRIPTION
- One phase will load before the native libraries; the other loads after
- game library does not contain fields directly any more, it contains
  functions that return the game state/color signal. In order to not do
  this, the game library would have to load after runtime init returns
  and the external user registers its functions.
- Refactored metatable hack out of actuators
