### PR TITLE
Added memory pool allocator implementation

### DIFF
--- a/controller/inc/pool_alloc.h
+++ b/controller/inc/pool_alloc.h
@@ -1,0 +1,46 @@
+// Licensed to Pioneers in Engineering under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  Pioneers in Engineering licenses
+// this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License
+
+#ifndef INC_POOL_ALLOC_H_
+#define INC_POOL_ALLOC_H_
+
+#include <string.h>
+
+// This module implements a memory pool allocator. Because of the optimizations
+// used in this module, there are at most 32 memory blocks allowed. Each memory
+// block is rounded up to a multiple of 4 bytes.
+
+typedef struct _pool_alloc *pool_alloc_t;
+
+// Returns the total size that this memory pool will require (in bytes).
+// If the input is invalid (too many blocks) the return will be 0.
+extern size_t pool_alloc_get_size(size_t blocksize, size_t blockcnt);
+
+// Allocate a new memory pool. Returns null on failure. The memory will be
+// allocated using the passed-in allocator function. No cleanup is necessary
+// to deallocate the pool.
+extern pool_alloc_t pool_alloc_create(size_t blocksize, size_t blockcnt,
+  void *(*alloc_func)(size_t));
+
+// Allocates a block from the memory pool. Returns null on failure.
+extern void *pool_alloc_block(pool_alloc_t pool);
+
+// Frees the passed-in block. Freeing null is not an error. Double free is
+// undefined.
+extern void pool_alloc_free(void *block);
+
+#endif  // INC_POOL_ALLOC_H_

--- a/controller/src/pool_alloc.c
+++ b/controller/src/pool_alloc.c
@@ -1,0 +1,119 @@
+// Licensed to Pioneers in Engineering under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  Pioneers in Engineering licenses
+// this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License
+
+#include "inc/pool_alloc.h"
+
+#include <stdint.h>
+
+struct _pool_alloc {
+    // 1 bit is free, 0 bit is allocated
+    // LSB is earlier block, MSB is later block
+    uint32_t alloc_state;
+    // Rounded up and including block header
+    uint32_t block_size;
+};
+
+typedef struct _pool_block_hdr {
+    struct _pool_alloc *pool;
+    uint32_t idx;
+} pool_block_hdr;
+
+static size_t _pool_get_adjusted_block_size(size_t blocksize) {
+    // Round up blocksize
+    blocksize = (blocksize + 3) & (~3);
+
+    // Add the block header size
+    blocksize += sizeof(pool_block_hdr);
+
+    return blocksize;
+}
+
+static pool_block_hdr *_pool_get_block_addr(pool_alloc_t pool, size_t idx) {
+    return (pool_block_hdr *)(((uint8_t *)(pool)) +
+        sizeof(struct _pool_alloc) + pool->block_size * idx);
+}
+
+// Returns the total size that this memory pool will require (in bytes).
+size_t pool_alloc_get_size(size_t blocksize, size_t blockcnt) {
+    // Check blockcnt
+    if (blockcnt > 32) return 0;
+
+    blocksize = _pool_get_adjusted_block_size(blocksize);
+
+    return blocksize * blockcnt + sizeof(struct _pool_alloc);
+}
+
+// Allocate a new memory pool. Returns null on failure. The memory will be
+// allocated using the passed-in allocator function. No cleanup is necessary
+// to deallocate the pool.
+pool_alloc_t pool_alloc_create(size_t blocksize, size_t blockcnt,
+  void *(*alloc_func)(size_t)) {
+    size_t size = pool_alloc_get_size(blocksize, blockcnt);
+
+    if (!size) return NULL;
+
+    pool_alloc_t pool = alloc_func(size);
+    if (!pool) return NULL;
+
+    pool->block_size = _pool_get_adjusted_block_size(blocksize);
+
+    // This bit twiddling hack is used to clear all bits from bit index
+    // blockcnt to 31 (inclusive). The end result is that there will only
+    // be blockcnt 1 bits left.
+    if (blockcnt == 32)
+        pool->alloc_state = 0xFFFFFFFF;
+    else
+        pool->alloc_state = 0xFFFFFFFF & ((1 << blockcnt) - 1);
+
+    // Mark all the headers to point back to the pool.
+    for (int i = 0; i < blockcnt; i++) {
+        pool_block_hdr *blkhdr = _pool_get_block_addr(pool, i);
+        blkhdr->pool = pool;
+        blkhdr->idx = i;
+    }
+
+    return pool;
+}
+
+// Allocates a block from the memory pool. Returns null on failure.
+void *pool_alloc_block(pool_alloc_t pool) {
+    if (!pool) return NULL;
+
+    // No free blocks
+    if (!pool->alloc_state) return NULL;
+
+    // Should assemble into rbit, clz
+    int idx = __builtin_ctz(pool->alloc_state);
+
+    // Mark as allocated
+    pool->alloc_state &= ~(1 << idx);
+
+    // Get block address
+    pool_block_hdr *blkhdr = _pool_get_block_addr(pool, idx);
+
+    return ((uint8_t *)(blkhdr)) + sizeof(pool_block_hdr);
+}
+
+// Frees the passed-in block. Freeing null is not an error. Double free is
+// undefined.
+void pool_alloc_free(void *block) {
+    if (!block) return;
+
+    pool_block_hdr *blkhdr = (pool_block_hdr *)(block - sizeof(pool_block_hdr));
+    pool_alloc_t pool = blkhdr->pool;
+    pool->alloc_state |= (1 << blkhdr->idx);
+}

--- a/controller/tests/pool_alloc_test.c
+++ b/controller/tests/pool_alloc_test.c
@@ -1,0 +1,120 @@
+// Licensed to Pioneers in Engineering under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  Pioneers in Engineering licenses
+// this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "inc/pool_alloc.h"
+
+int pool_size_calc(void) {
+    // Note: This test requires 32-bit-ness.
+    return pool_alloc_get_size(4, 1) != 20;
+}
+
+int pool_size_rounding(void) {
+    // Note: This test requires 32-bit-ness.
+    return pool_alloc_get_size(1, 1) != 20;
+}
+
+int pool_basic_alloc(void) {
+    // Create a new pool
+    pool_alloc_t pool = pool_alloc_create(1, 32, malloc);
+    if (!pool) return 1;
+
+    // Try allocating all 32 blocks
+    for (int i = 0; i < 32; i++) {
+        void *block = pool_alloc_block(pool);
+        if (!block) return 1;
+    }
+
+    // Try allocating yet another block.
+    void *block = pool_alloc_block(pool);
+    if (block) return 1;
+
+    // Cleanup
+    free(pool);
+    return 0;
+}
+
+int pool_basic_alloc_limited(void) {
+    // Create a new pool
+    pool_alloc_t pool = pool_alloc_create(1, 4, malloc);
+    if (!pool) return 1;
+
+    // Try allocating all 4 blocks
+    for (int i = 0; i < 4; i++) {
+        void *block = pool_alloc_block(pool);
+        if (!block) return 1;
+    }
+
+    // Try allocating yet another block.
+    void *block = pool_alloc_block(pool);
+    if (block) return 1;
+
+    // Cleanup
+    free(pool);
+    return 0;
+}
+
+int pool_alloc_free_alloc(void) {
+    // Create a new pool
+    pool_alloc_t pool = pool_alloc_create(1, 2, malloc);
+    if (!pool) return 1;
+
+    // Try allocating blocks
+    void *block0 = pool_alloc_block(pool);
+    if (!block0) return 1;
+    void *block1 = pool_alloc_block(pool);
+    if (!block1) return 1;
+
+    // Free block0
+    pool_alloc_free(block0);
+
+    // Try allocating another block
+    void *blockx = pool_alloc_block(pool);
+    if (!blockx) return 1;
+
+    // This alloc should fail
+    void *blocky = pool_alloc_block(pool);
+    if (blocky) return 1;
+
+    // Cleanup
+    free(pool);
+    return 0;
+}
+
+#define run_test(X) {                                       \
+  int ret = X();                                            \
+  if (ret != 0) {                                           \
+    failures++;                                             \
+    fprintf(stderr, "Test %s FAILED!\n", #X);               \
+  } else {                                                  \
+    printf("Test %s passed.\n", #X);                        \
+  }                                                         \
+}
+int main(int argc, char **argv) {
+  int failures = 0;
+
+  run_test(pool_size_calc);
+  run_test(pool_size_rounding);
+  run_test(pool_basic_alloc);
+  run_test(pool_basic_alloc_limited);
+
+  run_test(pool_alloc_free_alloc);
+
+  return failures;
+}


### PR DESCRIPTION
This memory pool allocator uses a bitfield to track allocations.
It is restricted to 32 blocks total, but should be fairly efficient.
Allocation and deallocation should be O(1).
