### PR TITLE
Fix routing of smartsensor board after 2x5 change.

### DIFF
--- a/eda/smartsensor.brd
+++ b/eda/smartsensor.brd
@@ -36,27 +36,27 @@
 <layer number="26" name="bNames" color="19" fill="1" visible="yes" active="yes"/>
 <layer number="27" name="tValues" color="18" fill="1" visible="yes" active="yes"/>
 <layer number="28" name="bValues" color="19" fill="1" visible="yes" active="yes"/>
-<layer number="29" name="tStop" color="7" fill="3" visible="yes" active="yes"/>
-<layer number="30" name="bStop" color="7" fill="6" visible="yes" active="yes"/>
-<layer number="31" name="tCream" color="7" fill="4" visible="yes" active="yes"/>
-<layer number="32" name="bCream" color="7" fill="5" visible="yes" active="yes"/>
-<layer number="33" name="tFinish" color="6" fill="3" visible="yes" active="yes"/>
-<layer number="34" name="bFinish" color="6" fill="6" visible="yes" active="yes"/>
-<layer number="35" name="tGlue" color="7" fill="4" visible="yes" active="yes"/>
-<layer number="36" name="bGlue" color="7" fill="5" visible="yes" active="yes"/>
-<layer number="37" name="tTest" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="38" name="bTest" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="39" name="tKeepout" color="4" fill="11" visible="yes" active="yes"/>
-<layer number="40" name="bKeepout" color="1" fill="11" visible="yes" active="yes"/>
-<layer number="41" name="tRestrict" color="4" fill="10" visible="yes" active="yes"/>
-<layer number="42" name="bRestrict" color="1" fill="10" visible="yes" active="yes"/>
-<layer number="43" name="vRestrict" color="2" fill="10" visible="yes" active="yes"/>
-<layer number="44" name="Drills" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="29" name="tStop" color="7" fill="3" visible="no" active="yes"/>
+<layer number="30" name="bStop" color="7" fill="6" visible="no" active="yes"/>
+<layer number="31" name="tCream" color="7" fill="4" visible="no" active="yes"/>
+<layer number="32" name="bCream" color="7" fill="5" visible="no" active="yes"/>
+<layer number="33" name="tFinish" color="6" fill="3" visible="no" active="yes"/>
+<layer number="34" name="bFinish" color="6" fill="6" visible="no" active="yes"/>
+<layer number="35" name="tGlue" color="7" fill="4" visible="no" active="yes"/>
+<layer number="36" name="bGlue" color="7" fill="5" visible="no" active="yes"/>
+<layer number="37" name="tTest" color="7" fill="1" visible="no" active="yes"/>
+<layer number="38" name="bTest" color="7" fill="1" visible="no" active="yes"/>
+<layer number="39" name="tKeepout" color="4" fill="11" visible="no" active="yes"/>
+<layer number="40" name="bKeepout" color="1" fill="11" visible="no" active="yes"/>
+<layer number="41" name="tRestrict" color="4" fill="10" visible="no" active="yes"/>
+<layer number="42" name="bRestrict" color="1" fill="10" visible="no" active="yes"/>
+<layer number="43" name="vRestrict" color="2" fill="10" visible="no" active="yes"/>
+<layer number="44" name="Drills" color="7" fill="1" visible="no" active="yes"/>
 <layer number="45" name="Holes" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="46" name="Milling" color="3" fill="1" visible="yes" active="yes"/>
-<layer number="47" name="Measures" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="48" name="Document" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="49" name="Reference" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="46" name="Milling" color="3" fill="1" visible="no" active="yes"/>
+<layer number="47" name="Measures" color="7" fill="1" visible="no" active="yes"/>
+<layer number="48" name="Document" color="7" fill="1" visible="no" active="yes"/>
+<layer number="49" name="Reference" color="7" fill="1" visible="no" active="yes"/>
 <layer number="50" name="dxf" color="7" fill="1" visible="no" active="no"/>
 <layer number="51" name="tDocu" color="6" fill="1" visible="yes" active="yes"/>
 <layer number="52" name="bDocu" color="6" fill="1" visible="yes" active="yes"/>
@@ -73,44 +73,44 @@
 <layer number="98" name="Guide" color="6" fill="1" visible="no" active="no"/>
 <layer number="99" name="SpiceOrder" color="5" fill="1" visible="no" active="no"/>
 <layer number="100" name="Muster" color="7" fill="1" visible="no" active="no"/>
-<layer number="101" name="Patch_Top" color="12" fill="4" visible="yes" active="yes"/>
-<layer number="102" name="Vscore" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="103" name="tMap" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="104" name="Name" color="16" fill="1" visible="yes" active="yes"/>
-<layer number="105" name="tPlate" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="106" name="bPlate" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="107" name="Crop" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="108" name="fp8" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="109" name="fp9" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="110" name="fp0" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="116" name="Patch_BOT" color="9" fill="4" visible="yes" active="yes"/>
-<layer number="121" name="_tsilk" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="122" name="_bsilk" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="123" name="tTestmark" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="124" name="bTestmark" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="125" name="_tNames" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="131" name="tAdjust" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="132" name="bAdjust" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="144" name="Drill_legend" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="151" name="HeatSink" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="199" name="Contour" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="200" name="200bmp" color="1" fill="10" visible="yes" active="yes"/>
-<layer number="201" name="201bmp" color="2" fill="10" visible="yes" active="yes"/>
-<layer number="202" name="202bmp" color="3" fill="10" visible="yes" active="yes"/>
-<layer number="203" name="203bmp" color="4" fill="10" visible="yes" active="yes"/>
-<layer number="204" name="204bmp" color="5" fill="10" visible="yes" active="yes"/>
-<layer number="205" name="205bmp" color="6" fill="10" visible="yes" active="yes"/>
-<layer number="206" name="206bmp" color="7" fill="10" visible="yes" active="yes"/>
-<layer number="207" name="207bmp" color="8" fill="10" visible="yes" active="yes"/>
-<layer number="208" name="208bmp" color="9" fill="10" visible="yes" active="yes"/>
-<layer number="209" name="209bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="210" name="210bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="211" name="211bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="212" name="212bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="213" name="213bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="214" name="214bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="215" name="215bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="216" name="216bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="101" name="Patch_Top" color="12" fill="4" visible="no" active="yes"/>
+<layer number="102" name="Vscore" color="7" fill="1" visible="no" active="yes"/>
+<layer number="103" name="tMap" color="7" fill="1" visible="no" active="yes"/>
+<layer number="104" name="Name" color="16" fill="1" visible="no" active="yes"/>
+<layer number="105" name="tPlate" color="7" fill="1" visible="no" active="yes"/>
+<layer number="106" name="bPlate" color="7" fill="1" visible="no" active="yes"/>
+<layer number="107" name="Crop" color="7" fill="1" visible="no" active="yes"/>
+<layer number="108" name="fp8" color="7" fill="1" visible="no" active="yes"/>
+<layer number="109" name="fp9" color="7" fill="1" visible="no" active="yes"/>
+<layer number="110" name="fp0" color="7" fill="1" visible="no" active="yes"/>
+<layer number="116" name="Patch_BOT" color="9" fill="4" visible="no" active="yes"/>
+<layer number="121" name="_tsilk" color="7" fill="1" visible="no" active="yes"/>
+<layer number="122" name="_bsilk" color="7" fill="1" visible="no" active="yes"/>
+<layer number="123" name="tTestmark" color="7" fill="1" visible="no" active="yes"/>
+<layer number="124" name="bTestmark" color="7" fill="1" visible="no" active="yes"/>
+<layer number="125" name="_tNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="131" name="tAdjust" color="7" fill="1" visible="no" active="yes"/>
+<layer number="132" name="bAdjust" color="7" fill="1" visible="no" active="yes"/>
+<layer number="144" name="Drill_legend" color="7" fill="1" visible="no" active="yes"/>
+<layer number="151" name="HeatSink" color="7" fill="1" visible="no" active="yes"/>
+<layer number="199" name="Contour" color="7" fill="1" visible="no" active="yes"/>
+<layer number="200" name="200bmp" color="1" fill="10" visible="no" active="yes"/>
+<layer number="201" name="201bmp" color="2" fill="10" visible="no" active="yes"/>
+<layer number="202" name="202bmp" color="3" fill="10" visible="no" active="yes"/>
+<layer number="203" name="203bmp" color="4" fill="10" visible="no" active="yes"/>
+<layer number="204" name="204bmp" color="5" fill="10" visible="no" active="yes"/>
+<layer number="205" name="205bmp" color="6" fill="10" visible="no" active="yes"/>
+<layer number="206" name="206bmp" color="7" fill="10" visible="no" active="yes"/>
+<layer number="207" name="207bmp" color="8" fill="10" visible="no" active="yes"/>
+<layer number="208" name="208bmp" color="9" fill="10" visible="no" active="yes"/>
+<layer number="209" name="209bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="210" name="210bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="211" name="211bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="212" name="212bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="213" name="213bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="214" name="214bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="215" name="215bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="216" name="216bmp" color="7" fill="1" visible="no" active="yes"/>
 <layer number="217" name="217bmp" color="18" fill="1" visible="no" active="no"/>
 <layer number="218" name="218bmp" color="19" fill="1" visible="no" active="no"/>
 <layer number="219" name="219bmp" color="20" fill="1" visible="no" active="no"/>
@@ -121,7 +121,7 @@
 <layer number="224" name="224bmp" color="25" fill="1" visible="no" active="no"/>
 <layer number="250" name="Descript" color="3" fill="1" visible="no" active="no"/>
 <layer number="251" name="SMDround" color="12" fill="11" visible="no" active="no"/>
-<layer number="254" name="cooling" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="254" name="cooling" color="7" fill="1" visible="no" active="yes"/>
 </layers>
 <board>
 <plain>
@@ -1161,7 +1161,7 @@ design rules under a new name.</description>
 </element>
 <element name="R1" library="pie" package="R0603" value="10k" x="9.1186" y="22.7736375" smashed="yes">
 <attribute name="PIE-INT-REF-NUM" value="RESISTOR-GENERIC" x="9.1186" y="22.7736375" size="1.778" layer="27" display="off"/>
-<attribute name="NAME" x="6.639559375" y="22.224996875" size="0.6096" layer="25" font="vector" ratio="20"/>
+<attribute name="NAME" x="9.941559375" y="21.462996875" size="0.6096" layer="25" font="vector" ratio="20"/>
 </element>
 <element name="U$7" library="pie" package="2X5" value="SENSOR_CON_5PINPTH" x="6.985" y="14.9098" smashed="yes" rot="R90"/>
 <element name="U$8" library="pie" package="2X5-EDGE" value="SENSOR_CON_5PINSMD-EDGE" x="-0.635" y="14.9098" smashed="yes" rot="R180"/>
@@ -1315,10 +1315,10 @@ design rules under a new name.</description>
 <attribute name="VALUE" x="10.698484375" y="24.0538" size="0.6096" layer="27" ratio="20" rot="R180"/>
 </element>
 <element name="U$1" library="pie" package="PIE-LOGO-SMALL" value="" x="6.014721875" y="23.911559375" rot="MR0"/>
-<element name="RESET" library="pie" package="POGO_PIN_394" value="" x="9.779" y="21.209" smashed="yes">
-<attribute name="PIE-INT-REF-NUM" value="POGO-PIN" x="9.779" y="21.209" size="1.778" layer="27" display="off"/>
-<attribute name="NAME" x="5.588" y="20.828" size="0.762" layer="25" font="vector" ratio="15"/>
-<attribute name="VALUE" x="8.509" y="18.669" size="1.27" layer="27" font="vector"/>
+<element name="RESET" library="pie" package="POGO_PIN_394" value="" x="6.731" y="22.987" smashed="yes">
+<attribute name="PIE-INT-REF-NUM" value="POGO-PIN" x="6.731" y="22.987" size="1.778" layer="27" display="off"/>
+<attribute name="NAME" x="5.842" y="21.336" size="0.762" layer="25" font="vector" ratio="15"/>
+<attribute name="VALUE" x="5.461" y="20.447" size="1.27" layer="27" font="vector"/>
 </element>
 <element name="MOSI" library="pie" package="POGO_PIN_394" value="" x="10.16" y="5.842" smashed="yes">
 <attribute name="PIE-INT-REF-NUM" value="POGO-PIN" x="10.16" y="5.842" size="1.778" layer="27" display="off"/>
@@ -1368,17 +1368,21 @@ design rules under a new name.</description>
 <vertex x="33.02" y="27.94"/>
 <vertex x="33.02" y="0"/>
 </polygon>
-<wire x1="12.186" y1="14.9606" x2="8.3058" y2="14.9606" width="0.3048" layer="16"/>
 <contactref element="U$7" pad="5"/>
 <contactref element="U$7" pad="6"/>
 <contactref element="U$8" pad="5"/>
 <contactref element="U$8" pad="6"/>
-<wire x1="8.3058" y1="14.9606" x2="8.255" y2="14.9098" width="0.3048" layer="16"/>
-<wire x1="1.905" y1="14.9098" x2="5.715" y2="14.9098" width="0.3048" layer="16"/>
 <wire x1="12.186" y1="16.2306" x2="14.7066" y2="16.2306" width="0.3048" layer="16"/>
 <wire x1="14.7066" y1="16.2306" x2="14.732" y2="16.256" width="0.3048" layer="16"/>
 <via x="14.732" y="16.256" extent="1-16" drill="0.381"/>
-<wire x1="12.186" y1="14.9606" x2="12.186" y2="16.2306" width="0" layer="19" extent="16-16"/>
+<wire x1="1.905" y1="14.9098" x2="5.715" y2="14.9098" width="0.3048" layer="16"/>
+<wire x1="12.186" y1="14.9606" x2="10.2108" y2="14.9606" width="0.3048" layer="16"/>
+<wire x1="8.255" y1="14.9098" x2="10.16" y2="14.9098" width="0.3048" layer="16"/>
+<wire x1="10.16" y1="14.9098" x2="10.2108" y2="14.9606" width="0.3048" layer="16"/>
+<wire x1="12.186" y1="14.9606" x2="14.7066" y2="14.9606" width="0.3048" layer="16"/>
+<wire x1="14.7066" y1="14.9606" x2="14.732" y2="14.986" width="0.3048" layer="16"/>
+<via x="14.732" y="14.986" extent="1-16" drill="0.381"/>
+<wire x1="14.732" y1="14.986" x2="14.732" y2="15.24" width="0.3048" layer="1"/>
 </signal>
 <signal name="GND">
 <contactref element="C2" pad="2"/>
@@ -1474,23 +1478,13 @@ design rules under a new name.</description>
 <via x="1.37668125" y="21.640796875" extent="1-16" drill="0.381"/>
 <wire x1="4.4069" y1="8.47598125" x2="4.4069" y2="7.6064" width="0.2032" layer="1"/>
 <wire x1="4.4069" y1="7.6064" x2="4.66" y2="7.3533" width="0.2032" layer="1"/>
-<wire x1="10.4902" y1="14.9098" x2="14.732" y2="14.9098" width="0.3048" layer="1"/>
-<via x="14.732" y="14.9098" extent="1-16" drill="0.381"/>
-<wire x1="1.905" y1="12.3698" x2="5.5118" y2="12.3698" width="0.3048" layer="1"/>
-<wire x1="5.5118" y1="12.3698" x2="5.588" y2="12.446" width="0.3048" layer="1"/>
-<wire x1="8.509" y1="17.272" x2="10.287" y2="15.494" width="0.3048" layer="1"/>
-<wire x1="10.4902" y1="14.9098" x2="10.287" y2="15.113" width="0.3048" layer="1"/>
-<wire x1="10.287" y1="15.113" x2="10.287" y2="15.494" width="0.3048" layer="1"/>
-<wire x1="8.509" y1="17.272" x2="8.4328" y2="17.272" width="0.3048" layer="1"/>
-<wire x1="8.4328" y1="17.272" x2="8.255" y2="17.4498" width="0.3048" layer="1"/>
-<wire x1="1.905" y1="17.4498" x2="3.4798" y2="17.4498" width="0.3048" layer="1"/>
-<wire x1="1.905" y1="17.4498" x2="5.6642" y2="17.4498" width="0.3048" layer="1"/>
-<wire x1="5.6642" y1="17.4498" x2="5.715" y2="17.399" width="0.3048" layer="1"/>
 <via x="11.938" y="6.223" extent="1-16" drill="0.381"/>
 <wire x1="9.74" y1="7.3533" x2="10.8077" y2="7.3533" width="0.2032" layer="1"/>
 <wire x1="10.8077" y1="7.3533" x2="11.938" y2="6.223" width="0.2032" layer="1"/>
-<wire x1="1.905" y1="17.4498" x2="1.905" y2="17.4498" width="0" layer="19" extent="1-16"/>
-<wire x1="1.905" y1="12.3698" x2="1.905" y2="12.3698" width="0" layer="19" extent="1-16"/>
+<wire x1="1.905" y1="17.4498" x2="5.715" y2="17.4498" width="0.3048" layer="1"/>
+<wire x1="1.905" y1="12.3698" x2="5.715" y2="12.3698" width="0.3048" layer="1"/>
+<wire x1="5.715" y1="12.3698" x2="8.255" y2="12.3698" width="0.3048" layer="1"/>
+<wire x1="5.715" y1="17.4498" x2="8.255" y2="17.4498" width="0.3048" layer="1"/>
 </signal>
 <signal name="TX">
 <contactref element="U2" pad="1"/>
@@ -1553,12 +1547,14 @@ design rules under a new name.</description>
 <contactref element="R1" pad="1"/>
 <wire x1="11.51" y1="16.8148" x2="11.033759375" y2="16.8148" width="0.2032" layer="1"/>
 <wire x1="11.033759375" y1="16.8148" x2="11.033759375" y2="16.81988125" width="0.2032" layer="1"/>
-<wire x1="11.033759375" y1="16.81988125" x2="10.368278125" y2="17.4853625" width="0.2032" layer="1"/>
 <contactref element="RESET" pad="POGO_PIN"/>
-<wire x1="10.368278125" y1="17.4853625" x2="10.368278125" y2="20.619721875" width="0.2032" layer="1"/>
-<wire x1="10.368278125" y1="20.619721875" x2="9.779" y2="21.209" width="0.2032" layer="1"/>
-<wire x1="9.779" y1="21.209" x2="9.779" y2="21.2632375" width="0.2032" layer="1"/>
-<wire x1="9.779" y1="21.2632375" x2="8.2686" y2="22.7736375" width="0.2032" layer="1"/>
+<wire x1="11.033759375" y1="16.81988125" x2="10.73911875" y2="16.81988125" width="0.2032" layer="1"/>
+<wire x1="10.73911875" y1="16.81988125" x2="10.414" y2="17.145" width="0.2032" layer="1"/>
+<wire x1="10.414" y1="17.145" x2="10.414" y2="19.939" width="0.2032" layer="1"/>
+<wire x1="10.414" y1="19.939" x2="8.2686" y2="22.0844" width="0.2032" layer="1"/>
+<wire x1="8.2686" y1="22.7736375" x2="8.2686" y2="22.0844" width="0.2032" layer="1"/>
+<wire x1="6.731" y1="22.987" x2="8.0552375" y2="22.987" width="0.2032" layer="1"/>
+<wire x1="8.0552375" y1="22.987" x2="8.2686" y2="22.7736375" width="0.2032" layer="1"/>
 </signal>
 <signal name="IO2">
 <contactref element="U2" pad="20"/>
@@ -1582,8 +1578,6 @@ design rules under a new name.</description>
 </signal>
 <signal name="IO3">
 <contactref element="U2" pad="19"/>
-<wire x1="16.8085" y1="7.2453" x2="13.589" y2="10.4648" width="0.2032" layer="1"/>
-<wire x1="13.589" y1="10.4648" x2="11.51" y2="10.4648" width="0.2032" layer="1"/>
 <contactref element="R5" pad="2"/>
 <contactref element="C6" pad="1"/>
 <contactref element="SJ4" pad="2"/>
@@ -1600,6 +1594,12 @@ design rules under a new name.</description>
 <wire x1="19.812" y1="6.223" x2="19.558" y2="6.477" width="0.2032" layer="1"/>
 <wire x1="19.558" y1="6.477" x2="19.0763" y2="6.477" width="0.2032" layer="1"/>
 <wire x1="19.0763" y1="6.477" x2="18.2" y2="7.3533" width="0.2032" layer="1"/>
+<wire x1="16.129" y1="9.906" x2="16.129" y2="7.9248" width="0.2032" layer="1"/>
+<wire x1="16.129" y1="7.9248" x2="16.8085" y2="7.2453" width="0.2032" layer="1"/>
+<wire x1="11.51" y1="10.4648" x2="13.2842" y2="10.4648" width="0.2032" layer="1"/>
+<wire x1="13.2842" y1="10.4648" x2="13.462" y2="10.287" width="0.2032" layer="1"/>
+<wire x1="13.462" y1="10.287" x2="15.748" y2="10.287" width="0.2032" layer="1"/>
+<wire x1="15.748" y1="10.287" x2="16.129" y2="9.906" width="0.2032" layer="1"/>
 </signal>
 <signal name="IO0">
 <contactref element="U2" pad="16"/>
@@ -1613,15 +1613,11 @@ design rules under a new name.</description>
 <wire x1="11.51" y1="14.2748" x2="13.6652" y2="14.2748" width="0.2032" layer="1"/>
 <wire x1="13.6652" y1="14.2748" x2="15.24" y2="12.7" width="0.2032" layer="1"/>
 <via x="15.24" y="12.7" extent="1-16" drill="0.381"/>
-<wire x1="15.24" y1="12.7" x2="13.97" y2="11.43" width="0.2032" layer="16"/>
-<wire x1="13.97" y1="11.43" x2="13.97" y2="8.255" width="0.2032" layer="16"/>
 <wire x1="2.921" y1="7.3923" x2="2.96" y2="7.3533" width="0.2032" layer="1"/>
 <contactref element="SCK" pad="POGO_PIN"/>
 <wire x1="2.8457" y1="7.239" x2="2.96" y2="7.3533" width="0.2032" layer="1"/>
 <wire x1="2.9473" y1="7.366" x2="2.96" y2="7.3533" width="0.2032" layer="1"/>
 <wire x1="3.8363" y1="6.477" x2="2.96" y2="7.3533" width="0.2032" layer="1"/>
-<wire x1="13.97" y1="8.255" x2="13.716" y2="8.001" width="0.2032" layer="16"/>
-<wire x1="13.716" y1="8.001" x2="7.62" y2="8.001" width="0.2032" layer="16"/>
 <wire x1="7.62" y1="8.001" x2="7.366" y2="8.255" width="0.2032" layer="16"/>
 <wire x1="7.366" y1="8.255" x2="6.477" y2="8.255" width="0.2032" layer="16"/>
 <wire x1="6.35" y1="6.096" x2="6.604" y2="5.842" width="0.2032" layer="16"/>
@@ -1630,6 +1626,10 @@ design rules under a new name.</description>
 <wire x1="6.477" y1="8.255" x2="6.223" y2="8.001" width="0.2032" layer="16"/>
 <wire x1="6.223" y1="8.001" x2="6.223" y2="6.223" width="0.2032" layer="16"/>
 <wire x1="6.223" y1="6.223" x2="6.604" y2="5.842" width="0.2032" layer="16"/>
+<wire x1="7.62" y1="8.001" x2="14.351" y2="8.001" width="0.2032" layer="16"/>
+<wire x1="14.351" y1="8.001" x2="14.859" y2="8.509" width="0.2032" layer="16"/>
+<wire x1="14.859" y1="8.509" x2="14.859" y2="12.319" width="0.2032" layer="16"/>
+<wire x1="14.859" y1="12.319" x2="15.24" y2="12.7" width="0.2032" layer="16"/>
 </signal>
 <signal name="IO1">
 <contactref element="U2" pad="18"/>
@@ -1640,15 +1640,15 @@ design rules under a new name.</description>
 <wire x1="8.04" y1="5.5563" x2="7.932" y2="5.4483" width="0.2032" layer="1"/>
 <wire x1="7.932" y1="5.4483" x2="7.932" y2="3.9561" width="0.2032" layer="1"/>
 <wire x1="7.932" y1="3.9561" x2="8.04" y2="3.8481" width="0.2032" layer="1"/>
-<wire x1="11.51" y1="11.7348" x2="14.9352" y2="11.7348" width="0.2032" layer="1"/>
-<wire x1="14.9352" y1="11.7348" x2="15.24" y2="11.43" width="0.2032" layer="1"/>
-<via x="15.24" y="11.43" extent="1-16" drill="0.381"/>
-<wire x1="15.24" y1="11.43" x2="15.24" y2="8.382" width="0.2032" layer="16"/>
+<via x="15.621" y="11.43" extent="1-16" drill="0.381"/>
 <via x="6.858" y="7.62" extent="1-16" drill="0.381"/>
 <wire x1="8.04" y1="7.3533" x2="7.1247" y2="7.3533" width="0.2032" layer="1"/>
-<wire x1="15.24" y1="8.382" x2="14.478" y2="7.62" width="0.2032" layer="16"/>
 <wire x1="14.478" y1="7.62" x2="6.858" y2="7.62" width="0.2032" layer="16"/>
 <wire x1="7.1247" y1="7.3533" x2="6.858" y2="7.62" width="0.2032" layer="1"/>
+<wire x1="15.621" y1="11.43" x2="15.621" y2="8.763" width="0.2032" layer="16"/>
+<wire x1="15.621" y1="8.763" x2="14.478" y2="7.62" width="0.2032" layer="16"/>
+<wire x1="11.51" y1="11.7348" x2="15.3162" y2="11.7348" width="0.2032" layer="1"/>
+<wire x1="15.3162" y1="11.7348" x2="15.621" y2="11.43" width="0.2032" layer="1"/>
 </signal>
 <signal name="CONN4">
 <contactref element="IN1" pad="P$1"/>
@@ -1762,15 +1762,14 @@ design rules under a new name.</description>
 <signal name="LED">
 <contactref element="U2" pad="15"/>
 <contactref element="R6" pad="2"/>
-<wire x1="11.51" y1="15.5448" x2="11.064240625" y2="15.5448" width="0.2032" layer="1"/>
-<wire x1="11.064240625" y1="15.5448" x2="9.9568" y2="16.652240625" width="0.2032" layer="1"/>
 <wire x1="5.166359375" y1="22.3808375" x2="5.168" y2="22.382478125" width="0.2032" layer="1"/>
-<wire x1="9.9568" y1="16.652240625" x2="9.9568" y2="17.6022" width="0.2032" layer="1"/>
-<wire x1="9.9568" y1="17.6022" x2="8.89" y2="18.669" width="0.2032" layer="1"/>
-<wire x1="8.89" y1="18.669" x2="7.62" y2="18.669" width="0.2032" layer="1"/>
-<wire x1="7.62" y1="18.669" x2="6.985" y2="19.304" width="0.2032" layer="1"/>
-<wire x1="6.985" y1="19.304" x2="6.985" y2="20.565478125" width="0.2032" layer="1"/>
-<wire x1="6.985" y1="20.565478125" x2="5.168" y2="22.382478125" width="0.2032" layer="1"/>
+<wire x1="5.168" y1="22.382478125" x2="5.176521875" y2="22.382478125" width="0.2032" layer="1"/>
+<wire x1="5.176521875" y1="22.382478125" x2="6.35" y2="21.209" width="0.2032" layer="1"/>
+<wire x1="6.35" y1="21.209" x2="8.509" y2="21.209" width="0.2032" layer="1"/>
+<wire x1="8.509" y1="21.209" x2="10.033" y2="19.685" width="0.2032" layer="1"/>
+<wire x1="10.033" y1="19.685" x2="10.033" y2="16.129" width="0.2032" layer="1"/>
+<wire x1="10.033" y1="16.129" x2="10.6172" y2="15.5448" width="0.2032" layer="1"/>
+<wire x1="11.51" y1="15.5448" x2="10.6172" y2="15.5448" width="0.2032" layer="1"/>
 </signal>
 <signal name="N$1">
 <contactref element="R6" pad="1"/>
@@ -1823,64 +1822,63 @@ design rules under a new name.</description>
 <contactref element="U1" pad="12"/>
 <contactref element="U$7" pad="1"/>
 <contactref element="U$8" pad="1"/>
-<wire x1="8.255" y1="9.8298" x2="8.255" y2="9.779" width="0.2032" layer="1"/>
-<wire x1="8.255" y1="9.779" x2="7.112" y2="8.636" width="0.2032" layer="1"/>
-<wire x1="7.112" y1="8.636" x2="5.334" y2="8.636" width="0.2032" layer="1"/>
-<wire x1="5.334" y1="8.636" x2="4.318" y2="9.652" width="0.2032" layer="1"/>
-<wire x1="4.318" y1="9.652" x2="2.0828" y2="9.652" width="0.2032" layer="1"/>
-<wire x1="2.0828" y1="9.652" x2="1.905" y2="9.8298" width="0.2032" layer="1"/>
-<wire x1="8.255" y1="9.8298" x2="8.255" y2="10.287" width="0.2032" layer="16"/>
-<wire x1="8.255" y1="10.287" x2="11.684" y2="13.716" width="0.2032" layer="16"/>
-<wire x1="11.684" y1="13.716" x2="12.1606" y2="13.716" width="0.2032" layer="16"/>
-<wire x1="12.1606" y1="13.716" x2="12.186" y2="13.6906" width="0.2032" layer="16"/>
+<wire x1="8.255" y1="9.8298" x2="9.1948" y2="9.8298" width="0.2032" layer="16"/>
+<wire x1="9.1948" y1="9.8298" x2="9.525" y2="10.16" width="0.2032" layer="16"/>
+<wire x1="9.525" y1="10.16" x2="9.525" y2="12.954" width="0.2032" layer="16"/>
+<wire x1="9.525" y1="12.954" x2="10.2616" y2="13.6906" width="0.2032" layer="16"/>
+<wire x1="12.186" y1="13.6906" x2="10.2616" y2="13.6906" width="0.2032" layer="16"/>
+<wire x1="1.905" y1="9.8298" x2="3.7338" y2="9.8298" width="0.2032" layer="1"/>
+<wire x1="3.7338" y1="9.8298" x2="5.08" y2="11.176" width="0.2032" layer="1"/>
+<wire x1="5.08" y1="11.176" x2="6.9088" y2="11.176" width="0.2032" layer="1"/>
+<wire x1="6.9088" y1="11.176" x2="8.255" y2="9.8298" width="0.2032" layer="1"/>
 </signal>
 <signal name="B_N">
 <contactref element="U1" pad="10"/>
 <contactref element="U$7" pad="9"/>
 <contactref element="U$8" pad="9"/>
-<wire x1="8.255" y1="19.9898" x2="8.255" y2="20.066" width="0.2032" layer="16"/>
-<wire x1="8.255" y1="20.066" x2="7.112" y2="21.209" width="0.2032" layer="16"/>
-<wire x1="7.112" y1="21.209" x2="4.064" y2="21.209" width="0.2032" layer="16"/>
-<wire x1="4.064" y1="21.209" x2="2.794" y2="19.939" width="0.2032" layer="16"/>
-<wire x1="2.794" y1="19.939" x2="1.9558" y2="19.939" width="0.2032" layer="16"/>
-<wire x1="1.9558" y1="19.939" x2="1.905" y2="19.9898" width="0.2032" layer="16"/>
-<wire x1="12.186" y1="11.1506" x2="12.8016" y2="11.1506" width="0.2032" layer="16"/>
-<wire x1="12.8016" y1="11.1506" x2="13.462" y2="11.811" width="0.2032" layer="16"/>
-<wire x1="13.462" y1="11.811" x2="13.462" y2="15.367" width="0.2032" layer="16"/>
-<wire x1="13.462" y1="15.367" x2="13.208" y2="15.621" width="0.2032" layer="16"/>
-<wire x1="13.208" y1="15.621" x2="11.049" y2="15.621" width="0.2032" layer="16"/>
-<wire x1="11.049" y1="15.621" x2="9.779" y2="16.891" width="0.2032" layer="16"/>
-<wire x1="9.779" y1="16.891" x2="9.779" y2="18.4658" width="0.2032" layer="16"/>
-<wire x1="9.779" y1="18.4658" x2="8.255" y2="19.9898" width="0.2032" layer="16"/>
+<via x="14.097" y="11.049" extent="1-16" drill="0.508"/>
+<wire x1="12.186" y1="11.1506" x2="13.9954" y2="11.1506" width="0.2032" layer="16"/>
+<wire x1="13.9954" y1="11.1506" x2="14.097" y2="11.049" width="0.2032" layer="16"/>
+<wire x1="8.255" y1="19.9898" x2="9.0932" y2="19.9898" width="0.2032" layer="1"/>
+<wire x1="9.0932" y1="19.9898" x2="9.652" y2="19.431" width="0.2032" layer="1"/>
+<wire x1="9.652" y1="19.431" x2="9.652" y2="12.065" width="0.2032" layer="1"/>
+<wire x1="9.652" y1="12.065" x2="10.541" y2="11.176" width="0.2032" layer="1"/>
+<wire x1="10.541" y1="11.176" x2="13.97" y2="11.176" width="0.2032" layer="1"/>
+<wire x1="13.97" y1="11.176" x2="14.097" y2="11.049" width="0.2032" layer="1"/>
+<wire x1="1.905" y1="19.9898" x2="3.7338" y2="19.9898" width="0.2032" layer="16"/>
+<wire x1="3.7338" y1="19.9898" x2="5.08" y2="21.336" width="0.2032" layer="16"/>
+<wire x1="5.08" y1="21.336" x2="6.9088" y2="21.336" width="0.2032" layer="16"/>
+<wire x1="6.9088" y1="21.336" x2="8.255" y2="19.9898" width="0.2032" layer="16"/>
 </signal>
 <signal name="A_N">
 <contactref element="U1" pad="11"/>
 <contactref element="U$7" pad="2"/>
 <contactref element="U$8" pad="2"/>
-<wire x1="5.715" y1="9.8298" x2="1.905" y2="9.8298" width="0.2032" layer="16"/>
-<wire x1="5.715" y1="9.8298" x2="5.9182" y2="9.8298" width="0.2032" layer="16"/>
-<wire x1="5.9182" y1="9.8298" x2="7.112" y2="8.636" width="0.2032" layer="16"/>
-<wire x1="7.112" y1="8.636" x2="9.017" y2="8.636" width="0.2032" layer="16"/>
-<wire x1="11.684" y1="12.446" x2="12.1606" y2="12.446" width="0.2032" layer="16"/>
-<wire x1="12.1606" y1="12.446" x2="12.186" y2="12.4206" width="0.2032" layer="16"/>
-<wire x1="9.017" y1="8.636" x2="9.525" y2="9.144" width="0.2032" layer="16"/>
-<wire x1="9.525" y1="9.144" x2="9.525" y2="10.287" width="0.2032" layer="16"/>
-<wire x1="9.525" y1="10.287" x2="11.684" y2="12.446" width="0.2032" layer="16"/>
+<wire x1="5.715" y1="9.8298" x2="5.715" y2="9.271" width="0.2032" layer="16"/>
+<wire x1="5.715" y1="9.271" x2="6.35" y2="8.636" width="0.2032" layer="16"/>
+<wire x1="6.35" y1="8.636" x2="8.89" y2="8.636" width="0.2032" layer="16"/>
+<wire x1="8.89" y1="8.636" x2="9.906" y2="9.652" width="0.2032" layer="16"/>
+<wire x1="9.906" y1="9.652" x2="9.906" y2="12.065" width="0.2032" layer="16"/>
+<wire x1="9.906" y1="12.065" x2="10.2616" y2="12.4206" width="0.2032" layer="16"/>
+<wire x1="12.186" y1="12.4206" x2="10.2616" y2="12.4206" width="0.2032" layer="16"/>
+<wire x1="1.905" y1="9.8298" x2="5.715" y2="9.8298" width="0.2032" layer="16"/>
 </signal>
 <signal name="B_P">
 <contactref element="U1" pad="9"/>
 <contactref element="U$7" pad="10"/>
 <contactref element="U$8" pad="10"/>
-<wire x1="5.715" y1="19.9898" x2="1.905" y2="19.9898" width="0.2032" layer="1"/>
-<wire x1="12.186" y1="9.8806" x2="10.1854" y2="9.8806" width="0.2032" layer="16"/>
-<wire x1="10.1854" y1="9.8806" x2="9.525" y2="10.541" width="0.2032" layer="1"/>
-<wire x1="9.525" y1="10.541" x2="9.525" y2="15.494" width="0.2032" layer="1"/>
-<wire x1="6.985" y1="18.7198" x2="5.715" y2="19.9898" width="0.2032" layer="1"/>
-<via x="10.1854" y="9.8806" extent="1-16" drill="0.381"/>
-<wire x1="9.525" y1="15.494" x2="8.89" y2="16.129" width="0.2032" layer="1"/>
-<wire x1="8.89" y1="16.129" x2="7.62" y2="16.129" width="0.2032" layer="1"/>
-<wire x1="6.985" y1="16.764" x2="6.985" y2="18.7198" width="0.2032" layer="1"/>
-<wire x1="7.62" y1="16.129" x2="6.985" y2="16.764" width="0.2032" layer="1"/>
+<via x="14.097" y="9.525" extent="1-16" drill="0.508"/>
+<wire x1="12.186" y1="9.8806" x2="13.7414" y2="9.8806" width="0.2032" layer="16"/>
+<wire x1="13.7414" y1="9.8806" x2="14.097" y2="9.525" width="0.2032" layer="16"/>
+<wire x1="5.715" y1="19.9898" x2="5.715" y2="19.939" width="0.2032" layer="1"/>
+<wire x1="5.715" y1="19.939" x2="6.858" y2="18.796" width="0.2032" layer="1"/>
+<wire x1="6.858" y1="18.796" x2="8.89" y2="18.796" width="0.2032" layer="1"/>
+<wire x1="8.89" y1="18.796" x2="9.271" y2="18.415" width="0.2032" layer="1"/>
+<wire x1="9.271" y1="18.415" x2="9.271" y2="11.176" width="0.2032" layer="1"/>
+<wire x1="9.271" y1="11.176" x2="10.541" y2="9.906" width="0.2032" layer="1"/>
+<wire x1="10.541" y1="9.906" x2="13.716" y2="9.906" width="0.2032" layer="1"/>
+<wire x1="13.716" y1="9.906" x2="14.097" y2="9.525" width="0.2032" layer="1"/>
+<wire x1="1.905" y1="19.9898" x2="5.715" y2="19.9898" width="0.2032" layer="1"/>
 </signal>
 </signals>
 <errors>

--- a/eda/smartsensor_jig.brd
+++ b/eda/smartsensor_jig.brd
@@ -36,27 +36,27 @@
 <layer number="26" name="bNames" color="19" fill="1" visible="yes" active="yes"/>
 <layer number="27" name="tValues" color="18" fill="1" visible="yes" active="yes"/>
 <layer number="28" name="bValues" color="19" fill="1" visible="yes" active="yes"/>
-<layer number="29" name="tStop" color="7" fill="3" visible="yes" active="yes"/>
-<layer number="30" name="bStop" color="7" fill="6" visible="yes" active="yes"/>
-<layer number="31" name="tCream" color="7" fill="4" visible="yes" active="yes"/>
-<layer number="32" name="bCream" color="7" fill="5" visible="yes" active="yes"/>
-<layer number="33" name="tFinish" color="6" fill="3" visible="yes" active="yes"/>
-<layer number="34" name="bFinish" color="6" fill="6" visible="yes" active="yes"/>
-<layer number="35" name="tGlue" color="7" fill="4" visible="yes" active="yes"/>
-<layer number="36" name="bGlue" color="7" fill="5" visible="yes" active="yes"/>
-<layer number="37" name="tTest" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="38" name="bTest" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="39" name="tKeepout" color="4" fill="11" visible="yes" active="yes"/>
-<layer number="40" name="bKeepout" color="1" fill="11" visible="yes" active="yes"/>
-<layer number="41" name="tRestrict" color="4" fill="10" visible="yes" active="yes"/>
-<layer number="42" name="bRestrict" color="1" fill="10" visible="yes" active="yes"/>
-<layer number="43" name="vRestrict" color="2" fill="10" visible="yes" active="yes"/>
-<layer number="44" name="Drills" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="29" name="tStop" color="7" fill="3" visible="no" active="yes"/>
+<layer number="30" name="bStop" color="7" fill="6" visible="no" active="yes"/>
+<layer number="31" name="tCream" color="7" fill="4" visible="no" active="yes"/>
+<layer number="32" name="bCream" color="7" fill="5" visible="no" active="yes"/>
+<layer number="33" name="tFinish" color="6" fill="3" visible="no" active="yes"/>
+<layer number="34" name="bFinish" color="6" fill="6" visible="no" active="yes"/>
+<layer number="35" name="tGlue" color="7" fill="4" visible="no" active="yes"/>
+<layer number="36" name="bGlue" color="7" fill="5" visible="no" active="yes"/>
+<layer number="37" name="tTest" color="7" fill="1" visible="no" active="yes"/>
+<layer number="38" name="bTest" color="7" fill="1" visible="no" active="yes"/>
+<layer number="39" name="tKeepout" color="4" fill="11" visible="no" active="yes"/>
+<layer number="40" name="bKeepout" color="1" fill="11" visible="no" active="yes"/>
+<layer number="41" name="tRestrict" color="4" fill="10" visible="no" active="yes"/>
+<layer number="42" name="bRestrict" color="1" fill="10" visible="no" active="yes"/>
+<layer number="43" name="vRestrict" color="2" fill="10" visible="no" active="yes"/>
+<layer number="44" name="Drills" color="7" fill="1" visible="no" active="yes"/>
 <layer number="45" name="Holes" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="46" name="Milling" color="3" fill="1" visible="yes" active="yes"/>
-<layer number="47" name="Measures" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="48" name="Document" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="49" name="Reference" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="46" name="Milling" color="3" fill="1" visible="no" active="yes"/>
+<layer number="47" name="Measures" color="7" fill="1" visible="no" active="yes"/>
+<layer number="48" name="Document" color="7" fill="1" visible="no" active="yes"/>
+<layer number="49" name="Reference" color="7" fill="1" visible="no" active="yes"/>
 <layer number="50" name="dxf" color="7" fill="1" visible="no" active="no"/>
 <layer number="51" name="tDocu" color="6" fill="1" visible="yes" active="yes"/>
 <layer number="52" name="bDocu" color="6" fill="1" visible="yes" active="yes"/>
@@ -73,44 +73,44 @@
 <layer number="98" name="Guide" color="6" fill="1" visible="no" active="no"/>
 <layer number="99" name="SpiceOrder" color="5" fill="1" visible="no" active="no"/>
 <layer number="100" name="Muster" color="7" fill="1" visible="no" active="no"/>
-<layer number="101" name="Patch_Top" color="12" fill="4" visible="yes" active="yes"/>
-<layer number="102" name="Vscore" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="103" name="tMap" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="104" name="Name" color="16" fill="1" visible="yes" active="yes"/>
-<layer number="105" name="tPlate" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="106" name="bPlate" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="107" name="Crop" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="108" name="fp8" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="109" name="fp9" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="110" name="fp0" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="116" name="Patch_BOT" color="9" fill="4" visible="yes" active="yes"/>
-<layer number="121" name="_tsilk" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="122" name="_bsilk" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="123" name="tTestmark" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="124" name="bTestmark" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="125" name="_tNames" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="131" name="tAdjust" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="132" name="bAdjust" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="144" name="Drill_legend" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="151" name="HeatSink" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="199" name="Contour" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="200" name="200bmp" color="1" fill="10" visible="yes" active="yes"/>
-<layer number="201" name="201bmp" color="2" fill="10" visible="yes" active="yes"/>
-<layer number="202" name="202bmp" color="3" fill="10" visible="yes" active="yes"/>
-<layer number="203" name="203bmp" color="4" fill="10" visible="yes" active="yes"/>
-<layer number="204" name="204bmp" color="5" fill="10" visible="yes" active="yes"/>
-<layer number="205" name="205bmp" color="6" fill="10" visible="yes" active="yes"/>
-<layer number="206" name="206bmp" color="7" fill="10" visible="yes" active="yes"/>
-<layer number="207" name="207bmp" color="8" fill="10" visible="yes" active="yes"/>
-<layer number="208" name="208bmp" color="9" fill="10" visible="yes" active="yes"/>
-<layer number="209" name="209bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="210" name="210bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="211" name="211bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="212" name="212bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="213" name="213bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="214" name="214bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="215" name="215bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="216" name="216bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="101" name="Patch_Top" color="12" fill="4" visible="no" active="yes"/>
+<layer number="102" name="Vscore" color="7" fill="1" visible="no" active="yes"/>
+<layer number="103" name="tMap" color="7" fill="1" visible="no" active="yes"/>
+<layer number="104" name="Name" color="16" fill="1" visible="no" active="yes"/>
+<layer number="105" name="tPlate" color="7" fill="1" visible="no" active="yes"/>
+<layer number="106" name="bPlate" color="7" fill="1" visible="no" active="yes"/>
+<layer number="107" name="Crop" color="7" fill="1" visible="no" active="yes"/>
+<layer number="108" name="fp8" color="7" fill="1" visible="no" active="yes"/>
+<layer number="109" name="fp9" color="7" fill="1" visible="no" active="yes"/>
+<layer number="110" name="fp0" color="7" fill="1" visible="no" active="yes"/>
+<layer number="116" name="Patch_BOT" color="9" fill="4" visible="no" active="yes"/>
+<layer number="121" name="_tsilk" color="7" fill="1" visible="no" active="yes"/>
+<layer number="122" name="_bsilk" color="7" fill="1" visible="no" active="yes"/>
+<layer number="123" name="tTestmark" color="7" fill="1" visible="no" active="yes"/>
+<layer number="124" name="bTestmark" color="7" fill="1" visible="no" active="yes"/>
+<layer number="125" name="_tNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="131" name="tAdjust" color="7" fill="1" visible="no" active="yes"/>
+<layer number="132" name="bAdjust" color="7" fill="1" visible="no" active="yes"/>
+<layer number="144" name="Drill_legend" color="7" fill="1" visible="no" active="yes"/>
+<layer number="151" name="HeatSink" color="7" fill="1" visible="no" active="yes"/>
+<layer number="199" name="Contour" color="7" fill="1" visible="no" active="yes"/>
+<layer number="200" name="200bmp" color="1" fill="10" visible="no" active="yes"/>
+<layer number="201" name="201bmp" color="2" fill="10" visible="no" active="yes"/>
+<layer number="202" name="202bmp" color="3" fill="10" visible="no" active="yes"/>
+<layer number="203" name="203bmp" color="4" fill="10" visible="no" active="yes"/>
+<layer number="204" name="204bmp" color="5" fill="10" visible="no" active="yes"/>
+<layer number="205" name="205bmp" color="6" fill="10" visible="no" active="yes"/>
+<layer number="206" name="206bmp" color="7" fill="10" visible="no" active="yes"/>
+<layer number="207" name="207bmp" color="8" fill="10" visible="no" active="yes"/>
+<layer number="208" name="208bmp" color="9" fill="10" visible="no" active="yes"/>
+<layer number="209" name="209bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="210" name="210bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="211" name="211bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="212" name="212bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="213" name="213bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="214" name="214bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="215" name="215bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="216" name="216bmp" color="7" fill="1" visible="no" active="yes"/>
 <layer number="217" name="217bmp" color="18" fill="1" visible="no" active="no"/>
 <layer number="218" name="218bmp" color="19" fill="1" visible="no" active="no"/>
 <layer number="219" name="219bmp" color="20" fill="1" visible="no" active="no"/>
@@ -121,7 +121,7 @@
 <layer number="224" name="224bmp" color="25" fill="1" visible="no" active="no"/>
 <layer number="250" name="Descript" color="3" fill="1" visible="no" active="no"/>
 <layer number="251" name="SMDround" color="12" fill="11" visible="no" active="no"/>
-<layer number="254" name="cooling" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="254" name="cooling" color="7" fill="1" visible="no" active="yes"/>
 </layers>
 <board>
 <plain>
@@ -897,10 +897,10 @@ design rules under a new name.</description>
 <attribute name="VALUE" x="25.146" y="3.302" size="1.27" layer="27" font="vector"/>
 <attribute name="PIE-INT-REF-NUM" value="POGO-PIN" x="26.416" y="5.842" size="1.778" layer="27" display="off"/>
 </element>
-<element name="RESET" library="pie" package="POGO_PIN_394" value="" x="23.241" y="21.209" smashed="yes" rot="R270">
-<attribute name="NAME" x="24.511" y="21.59" size="1.4224" layer="25" font="vector" ratio="15" align="top-left"/>
-<attribute name="VALUE" x="20.701" y="22.479" size="1.27" layer="27" font="vector" rot="R270"/>
-<attribute name="PIE-INT-REF-NUM" value="POGO-PIN" x="23.241" y="21.209" size="1.778" layer="27" rot="R270" display="off"/>
+<element name="RESET" library="pie" package="POGO_PIN_394" value="" x="26.289" y="22.987" smashed="yes" rot="R270">
+<attribute name="NAME" x="27.559" y="23.368" size="1.4224" layer="25" font="vector" ratio="15" align="top-left"/>
+<attribute name="VALUE" x="23.749" y="24.257" size="1.27" layer="27" font="vector" rot="R270"/>
+<attribute name="PIE-INT-REF-NUM" value="POGO-PIN" x="26.289" y="22.987" size="1.778" layer="27" rot="R270" display="off"/>
 </element>
 <element name="5V" library="pie" package="POGO_PIN_394" value="" x="8.89" y="25.4" smashed="yes" rot="R270">
 <attribute name="NAME" x="10.16" y="25.781" size="1.4224" layer="25" font="vector" ratio="15" align="top-left"/>
@@ -942,8 +942,8 @@ design rules under a new name.</description>
 <signal name="RESET">
 <contactref element="J2" pad="5"/>
 <contactref element="RESET" pad="POGO_PIN"/>
-<wire x1="5.08" y1="7.62" x2="9.652" y2="7.62" width="0.3048" layer="16"/>
-<wire x1="9.652" y1="7.62" x2="23.241" y2="21.209" width="0.3048" layer="16"/>
+<wire x1="5.08" y1="7.62" x2="10.922" y2="7.62" width="0.3048" layer="16"/>
+<wire x1="10.922" y1="7.62" x2="26.289" y2="22.987" width="0.3048" layer="16"/>
 </signal>
 <signal name="SCK">
 <contactref element="J2" pad="3"/>


### PR DESCRIPTION
The arrangement of the VCC/GND planes and overlapping pads of the
sideways smartsensor conenctor interact in a strange way and
cause EAGLE to not clearly indicate the presence of airwires.

This commit repairs the airwires introduced in the 2x4 --> 2x5 change
that were hidden by this idiosyncracy of EAGLE.
