### PR TITLE
Fix silkscreen on Beaglebone top board

### DIFF
--- a/eda/cape.brd
+++ b/eda/cape.brd
@@ -150,11 +150,11 @@ Version 1 Rev. B</text>
 Design by: Casey Duckering
 This design is open source hardware.
 For more information, visit
-pioners.berkeley.edu/opensource.</text>
+pioneers.berkeley.edu/opensource.</text>
 <text x="7.62" y="10.16" size="1.27" layer="27" font="vector" ratio="15" align="bottom-right">12V</text>
 <text x="7.62" y="15.24" size="1.27" layer="27" font="vector" ratio="15" align="top-right">GND</text>
-<text x="71.12" y="17.78" size="0.9144" layer="1" font="vector" ratio="20" rot="R90" align="bottom-center">v1  revC
-31 Oct 2015</text>
+<text x="71.12" y="17.78" size="0.9144" layer="1" font="vector" ratio="20" rot="R90" align="bottom-center">v1  revB
+5 Nov 2015</text>
 <hole x="1.524" y="20.701" drill="1.905"/>
 <hole x="3.81" y="20.701" drill="1.905"/>
 <hole x="6.096" y="20.701" drill="1.905"/>
@@ -1177,11 +1177,11 @@ design rules under a new name.</description>
 </element>
 <element name="CAPE" library="SparkFun-Boards" package="BEAGLE_BONE_BLACK_CAPE" value="BEAGLE_BONE_BLACK_CAPE" x="-11.43" y="0" smashed="yes"/>
 <element name="VREG" library="pie" package="TO-220" value="LT323A" x="19.05" y="25.4" smashed="yes">
-<attribute name="NAME" x="13.335" y="21.59" size="1.27" layer="25" font="vector" ratio="15" rot="R90"/>
-<attribute name="VALUE" x="27.305" y="27.813" size="1.27" layer="27" font="vector" rot="R90"/>
+<attribute name="NAME" x="12.319" y="21.082" size="1.27" layer="25" font="vector" ratio="15" rot="R90"/>
+<attribute name="VALUE" x="28.067" y="27.94" size="1.27" layer="27" font="vector" ratio="15" rot="R90"/>
 </element>
 <element name="U$3" library="pie" package="OSHW-LOGO-M" value="" x="62.484" y="10.541"/>
-<element name="U$6" library="pie" package="PIE-LOGO" value="" x="44.45" y="27.94"/>
+<element name="U$6" library="pie" package="PIE-LOGO" value="" x="45.72" y="28.448"/>
 <element name="R1" library="pie" package="R0603" value="130" x="10.16" y="45.72" smashed="yes">
 <attribute name="PIE-INT-REF-NUM" value="RESISTOR-GENERIC" x="10.16" y="52.07" size="1.778" layer="27" display="off"/>
 <attribute name="NAME" x="8.89" y="46.99" size="1.27" layer="25" font="vector" ratio="15"/>

--- a/eda/cape.brd
+++ b/eda/cape.brd
@@ -144,27 +144,32 @@
 <wire x1="72.06" y1="54.6" x2="0" y2="54.6" width="0.254" layer="20"/>
 <wire x1="0" y1="54.6" x2="0" y2="0" width="0.254" layer="20"/>
 <text x="44.45" y="46.99" size="1.4224" layer="21" font="vector" ratio="15" align="top-center">Pioneers in Engineering
-Top Board
-Version 1 Rev. A</text>
+Woodstock
+Version 1 Rev. B</text>
 <text x="44.45" y="13.97" size="0.889" layer="21" font="vector" ratio="15" align="top-center">(c) Pioneers in Engineering.
 Design by: Casey Duckering
 This design is open source hardware.
 For more information, visit
 pioners.berkeley.edu/opensource.</text>
-<hole x="8.89" y="39.37" drill="3.175"/>
-<hole x="5.334" y="39.37" drill="3.175"/>
-<hole x="8.89" y="35.56" drill="3.175"/>
-<hole x="8.89" y="31.75" drill="3.175"/>
-<hole x="8.89" y="27.94" drill="3.175"/>
-<hole x="5.334" y="20.32" drill="3.175"/>
-<hole x="1.778" y="20.32" drill="3.175"/>
-<hole x="1.778" y="39.37" drill="3.175"/>
-<hole x="8.89" y="24.13" drill="3.175"/>
-<hole x="8.89" y="20.32" drill="3.175"/>
-<text x="7.62" y="10.16" size="1.27" layer="27" font="vector" ratio="15" align="bottom-right">GND</text>
-<text x="7.62" y="15.24" size="1.27" layer="27" font="vector" ratio="15" align="top-right">12V</text>
-<text x="71.12" y="17.78" size="0.9144" layer="1" font="vector" ratio="20" rot="R90" align="bottom-center">v1  revA
+<text x="7.62" y="10.16" size="1.27" layer="27" font="vector" ratio="15" align="bottom-right">12V</text>
+<text x="7.62" y="15.24" size="1.27" layer="27" font="vector" ratio="15" align="top-right">GND</text>
+<text x="71.12" y="17.78" size="0.9144" layer="1" font="vector" ratio="20" rot="R90" align="bottom-center">v1  revB
 3 Oct 2015</text>
+<hole x="1.524" y="20.701" drill="1.905"/>
+<hole x="3.81" y="20.701" drill="1.905"/>
+<hole x="6.096" y="20.701" drill="1.905"/>
+<hole x="8.382" y="20.701" drill="1.905"/>
+<hole x="8.382" y="27.432" drill="1.905"/>
+<hole x="8.382" y="25.146" drill="1.905"/>
+<hole x="8.382" y="22.86" drill="1.905"/>
+<hole x="8.382" y="29.591" drill="1.905"/>
+<hole x="8.382" y="36.322" drill="1.905"/>
+<hole x="8.382" y="34.036" drill="1.905"/>
+<hole x="8.382" y="31.75" drill="1.905"/>
+<hole x="1.524" y="38.481" drill="1.905"/>
+<hole x="3.81" y="38.481" drill="1.905"/>
+<hole x="6.096" y="38.481" drill="1.905"/>
+<hole x="8.382" y="38.481" drill="1.905"/>
 </plain>
 <libraries>
 <library name="pie">
@@ -172,17 +177,21 @@ pioners.berkeley.edu/opensource.</text>
 A collection of parts and footprints made for the PiE Robotics Competition.&lt;br/&gt;&lt;br/&gt;
 (c) Pioneers in Engineering and Tau Beta Pi CA-A, UC Berkeley.</description>
 <packages>
-<package name="1206">
-<wire x1="-0.965" y1="0.787" x2="0.965" y2="0.787" width="0.1016" layer="51"/>
-<wire x1="-0.965" y1="-0.787" x2="0.965" y2="-0.787" width="0.1016" layer="51"/>
-<smd name="1" x="-1.4" y="0" dx="1.6" dy="1.8" layer="1"/>
-<smd name="2" x="1.4" y="0" dx="1.6" dy="1.8" layer="1"/>
-<text x="-1.905" y="1.27" size="1.27" layer="25" font="vector" ratio="10">&gt;NAME</text>
-<text x="-1.905" y="-2.54" size="1.27" layer="27" font="vector">&gt;VALUE</text>
-<rectangle x1="-1.7018" y1="-0.8509" x2="-0.9517" y2="0.8491" layer="51"/>
-<rectangle x1="0.9517" y1="-0.8491" x2="1.7018" y2="0.8509" layer="51"/>
-<rectangle x1="-0.1999" y1="-0.4001" x2="0.1999" y2="0.4001" layer="35"/>
-<rectangle x1="-2.794" y1="-1.016" x2="2.794" y2="1.016" layer="39"/>
+<package name="EIA3216">
+<wire x1="-1" y1="-1.2" x2="-2.5" y2="-1.2" width="0.2032" layer="21"/>
+<wire x1="-2.5" y1="-1.2" x2="-2.5" y2="1.2" width="0.2032" layer="21"/>
+<wire x1="-2.5" y1="1.2" x2="-1" y2="1.2" width="0.2032" layer="21"/>
+<wire x1="1" y1="-1.2" x2="2.1" y2="-1.2" width="0.2032" layer="21"/>
+<wire x1="2.1" y1="-1.2" x2="2.5" y2="-0.8" width="0.2032" layer="21"/>
+<wire x1="2.5" y1="-0.8" x2="2.5" y2="0.8" width="0.2032" layer="21"/>
+<wire x1="2.5" y1="0.8" x2="2.1" y2="1.2" width="0.2032" layer="21"/>
+<wire x1="2.1" y1="1.2" x2="1" y2="1.2" width="0.2032" layer="21"/>
+<wire x1="0.381" y1="1.016" x2="0.381" y2="-1.016" width="0.127" layer="21"/>
+<smd name="C" x="-1.4" y="0" dx="1.6" dy="1.4" layer="1" rot="R90"/>
+<smd name="A" x="1.4" y="0" dx="1.6" dy="1.4" layer="1" rot="R90"/>
+<text x="-2.54" y="1.905" size="1.27" layer="25" font="vector" ratio="10">&gt;NAME</text>
+<text x="-2.54" y="-3.175" size="1.27" layer="27" font="vector" ratio="10">&gt;VALUE</text>
+<rectangle x1="-3.175" y1="-1.524" x2="3.175" y2="1.524" layer="39"/>
 </package>
 <package name="ANDERSON_HORIZONTAL">
 <description>2-pin 25A Anderson Connector
@@ -1149,14 +1158,12 @@ design rules under a new name.</description>
 </pass>
 </autorouter>
 <elements>
-<element name="C1" library="pie" package="1206" value="2.2 uF TANT" x="20.193" y="8.89" smashed="yes" rot="R180">
-<attribute name="PIE-INT-REF-NUM" value="CAPACITOR-GENERIC" x="20.193" y="8.89" size="1.778" layer="27" rot="R180" display="off"/>
-<attribute name="NAME" x="17.018" y="9.525" size="1.27" layer="25" font="vector" ratio="15" rot="R180"/>
-<attribute name="VALUE" x="25.908" y="11.43" size="1.27" layer="27" font="vector" ratio="15" rot="R180"/>
+<element name="C1" library="pie" package="EIA3216" value="2.2 uF TANT" x="20.193" y="8.89" smashed="yes">
+<attribute name="NAME" x="23.368" y="8.255" size="1.27" layer="25" font="vector" ratio="15"/>
+<attribute name="VALUE" x="14.224" y="6.096" size="1.27" layer="27" font="vector" ratio="15"/>
 </element>
-<element name="C2" library="pie" package="1206" value="2.2 uF TANT" x="20.193" y="12.7" smashed="yes">
-<attribute name="PIE-INT-REF-NUM" value="CAPACITOR-GENERIC" x="20.193" y="12.7" size="1.778" layer="27" display="off"/>
-<attribute name="NAME" x="17.272" y="13.335" size="1.27" layer="25" font="vector" ratio="15" align="top-right"/>
+<element name="C2" library="pie" package="EIA3216" value="2.2 uF TANT" x="20.193" y="12.7" smashed="yes" rot="R180">
+<attribute name="NAME" x="23.114" y="12.065" size="1.27" layer="25" font="vector" ratio="15" rot="R180" align="top-right"/>
 </element>
 <element name="BATT" library="pie" package="ANDERSON_HORIZONTAL" value="12V" x="9.906" y="12.7" smashed="yes">
 <attribute name="PIE-INT-REF-NUM" value="Anderson" x="9.906" y="12.7" size="1.778" layer="27" display="off"/>
@@ -1188,10 +1195,10 @@ design rules under a new name.</description>
 </elements>
 <signals>
 <signal name="GND">
-<contactref element="C1" pad="1"/>
+<contactref element="C1" pad="A"/>
 <contactref element="BATT" pad="PIN1"/>
 <contactref element="VREG" pad="GND"/>
-<contactref element="C2" pad="1"/>
+<contactref element="C2" pad="A"/>
 <contactref element="CAPE" pad="P9.1"/>
 <contactref element="CAPE" pad="P9.2"/>
 <contactref element="J2" pad="GND"/>
@@ -1215,7 +1222,7 @@ design rules under a new name.</description>
 <contactref element="BATT" pad="PIN1-LEAD"/>
 </signal>
 <signal name="5V">
-<contactref element="C2" pad="2"/>
+<contactref element="C2" pad="C"/>
 <contactref element="VREG" pad="OUT"/>
 <contactref element="CAPE" pad="P9.3"/>
 <contactref element="CAPE" pad="P9.4"/>
@@ -1236,7 +1243,7 @@ design rules under a new name.</description>
 <signal name="12V">
 <contactref element="BATT" pad="PIN2"/>
 <contactref element="VREG" pad="IN"/>
-<contactref element="C1" pad="2"/>
+<contactref element="C1" pad="C"/>
 <contactref element="J2" pad="VCC"/>
 <wire x1="16.51" y1="16.51" x2="16.51" y2="15.367" width="1.524" layer="1"/>
 <wire x1="18.793" y1="8.89" x2="10.287" y2="8.89" width="0.508" layer="1"/>
@@ -1259,8 +1266,8 @@ design rules under a new name.</description>
 </signal>
 </signals>
 <errors>
-<approved hash="4,1,5400033f0ab43ce1"/>
 <approved hash="4,1,bd9193f51afa46e8"/>
+<approved hash="4,1,5400033f0ab43ce1"/>
 </errors>
 </board>
 </drawing>

--- a/eda/cape.brd
+++ b/eda/cape.brd
@@ -145,7 +145,7 @@
 <wire x1="0" y1="54.6" x2="0" y2="0" width="0.254" layer="20"/>
 <text x="44.45" y="46.99" size="1.4224" layer="21" font="vector" ratio="15" align="top-center">Pioneers in Engineering
 Woodstock
-Version 1 Rev. C</text>
+Version 1 Rev. B</text>
 <text x="44.45" y="13.97" size="0.889" layer="21" font="vector" ratio="15" align="top-center">(c) Pioneers in Engineering.
 Design by: Casey Duckering
 This design is open source hardware.
@@ -1158,12 +1158,12 @@ design rules under a new name.</description>
 </pass>
 </autorouter>
 <elements>
-<element name="C1" library="pie" package="EIA3216" value="2.2 uF TANT" x="22.987" y="8.89" smashed="yes">
-<attribute name="NAME" x="26.416" y="8.255" size="1.27" layer="25" font="vector" ratio="15"/>
-<attribute name="VALUE" x="17.018" y="6.096" size="1.27" layer="27" font="vector" ratio="15"/>
+<element name="C1" library="pie" package="EIA3216" value="2.2 uF TANT" x="22.987" y="8.89" smashed="yes" rot="R180">
+<attribute name="NAME" x="17.018" y="8.255" size="1.27" layer="25" font="vector" ratio="15"/>
+<attribute name="VALUE" x="28.702" y="7.112" size="1.27" layer="27" font="vector" ratio="15" rot="R180"/>
 </element>
-<element name="C2" library="pie" package="EIA3216" value="2.2 uF TANT" x="22.987" y="12.7" smashed="yes">
-<attribute name="NAME" x="28.829" y="13.208" size="1.27" layer="25" font="vector" ratio="15" align="top-right"/>
+<element name="C2" library="pie" package="EIA3216" value="2.2 uF TANT" x="22.987" y="12.7" smashed="yes" rot="R180">
+<attribute name="NAME" x="17.145" y="12.192" size="1.27" layer="25" font="vector" ratio="15" rot="R180" align="top-right"/>
 </element>
 <element name="BATT" library="pie" package="ANDERSON_HORIZONTAL" value="12V" x="9.906" y="12.7" smashed="yes">
 <attribute name="PIE-INT-REF-NUM" value="Anderson" x="9.906" y="12.7" size="1.778" layer="27" display="off"/>
@@ -1195,10 +1195,8 @@ design rules under a new name.</description>
 </elements>
 <signals>
 <signal name="GND">
-<contactref element="C1" pad="A"/>
 <contactref element="BATT" pad="PIN1"/>
 <contactref element="VREG" pad="GND"/>
-<contactref element="C2" pad="A"/>
 <contactref element="CAPE" pad="P9.1"/>
 <contactref element="CAPE" pad="P9.2"/>
 <contactref element="J2" pad="GND"/>
@@ -1220,9 +1218,10 @@ design rules under a new name.</description>
 <wire x1="12.7" y1="35.941" x2="14.986" y2="35.941" width="1.27" layer="1"/>
 <wire x1="14.986" y1="35.941" x2="19.177" y2="31.75" width="1.27" layer="1"/>
 <contactref element="BATT" pad="PIN1-LEAD"/>
+<contactref element="C1" pad="C"/>
+<contactref element="C2" pad="C"/>
 </signal>
 <signal name="5V">
-<contactref element="C2" pad="C"/>
 <contactref element="VREG" pad="OUT"/>
 <contactref element="J3" pad="VCC"/>
 <polygon width="0.4064" layer="16" isolate="0.3048">
@@ -1235,18 +1234,17 @@ design rules under a new name.</description>
 <contactref element="R1" pad="2"/>
 <via x="12.7" y="45.72" extent="1-16" drill="0.6"/>
 <wire x1="11.01" y1="45.72" x2="12.7" y2="45.72" width="0.4064" layer="1"/>
-<wire x1="21.59" y1="16.513" x2="21.59" y2="12.703" width="0.6096" layer="1"/>
-<wire x1="21.59" y1="12.703" x2="21.587" y2="12.7" width="0.6096" layer="1"/>
 <contactref element="CAPE" pad="P9.5"/>
 <contactref element="CAPE" pad="P9.6"/>
+<contactref element="C2" pad="A"/>
+<wire x1="21.59" y1="16.513" x2="21.587" y2="16.513" width="1.524" layer="1"/>
+<wire x1="21.587" y1="16.513" x2="21.587" y2="12.7" width="1.524" layer="1"/>
 </signal>
 <signal name="12V">
 <contactref element="BATT" pad="PIN2"/>
 <contactref element="VREG" pad="IN"/>
-<contactref element="C1" pad="C"/>
 <contactref element="J2" pad="VCC"/>
 <wire x1="16.51" y1="16.51" x2="16.51" y2="15.367" width="1.524" layer="1"/>
-<wire x1="21.587" y1="8.89" x2="10.287" y2="8.89" width="0.508" layer="1"/>
 <wire x1="63.5" y1="29.21" x2="60.96" y2="29.21" width="1.524" layer="16"/>
 <wire x1="10.287" y1="9.144" x2="16.51" y2="15.367" width="1.524" layer="1"/>
 <wire x1="11.938" y1="8.89" x2="10.033" y2="8.89" width="0.6096" layer="16"/>
@@ -1257,7 +1255,10 @@ design rules under a new name.</description>
 <wire x1="10.033" y1="8.89" x2="9.906" y2="8.763" width="0.6096" layer="1"/>
 <wire x1="9.906" y1="8.763" x2="40.513" y2="8.763" width="1.524" layer="16"/>
 <wire x1="40.513" y1="8.763" x2="60.96" y2="29.21" width="1.524" layer="16"/>
-<wire x1="4.572" y1="8.763" x2="9.906" y2="8.763" width="0" layer="19" extent="1-1"/>
+<contactref element="C1" pad="A"/>
+<wire x1="9.906" y1="8.763" x2="21.587" y2="8.763" width="0.508" layer="1"/>
+<wire x1="21.587" y1="8.763" x2="21.587" y2="8.89" width="0.508" layer="1"/>
+<wire x1="4.572" y1="8.763" x2="9.906" y2="8.763" width="0" layer="19" extent="1-16"/>
 </signal>
 <signal name="N$1">
 <contactref element="R1" pad="1"/>

--- a/eda/cape.brd
+++ b/eda/cape.brd
@@ -145,7 +145,7 @@
 <wire x1="0" y1="54.6" x2="0" y2="0" width="0.254" layer="20"/>
 <text x="44.45" y="46.99" size="1.4224" layer="21" font="vector" ratio="15" align="top-center">Pioneers in Engineering
 Woodstock
-Version 1 Rev. B</text>
+Version 1 Rev. C</text>
 <text x="44.45" y="13.97" size="0.889" layer="21" font="vector" ratio="15" align="top-center">(c) Pioneers in Engineering.
 Design by: Casey Duckering
 This design is open source hardware.
@@ -153,8 +153,8 @@ For more information, visit
 pioners.berkeley.edu/opensource.</text>
 <text x="7.62" y="10.16" size="1.27" layer="27" font="vector" ratio="15" align="bottom-right">12V</text>
 <text x="7.62" y="15.24" size="1.27" layer="27" font="vector" ratio="15" align="top-right">GND</text>
-<text x="71.12" y="17.78" size="0.9144" layer="1" font="vector" ratio="20" rot="R90" align="bottom-center">v1  revB
-28 Oct 2015</text>
+<text x="71.12" y="17.78" size="0.9144" layer="1" font="vector" ratio="20" rot="R90" align="bottom-center">v1  revC
+31 Oct 2015</text>
 <hole x="1.524" y="20.701" drill="1.905"/>
 <hole x="3.81" y="20.701" drill="1.905"/>
 <hole x="6.096" y="20.701" drill="1.905"/>
@@ -1158,12 +1158,12 @@ design rules under a new name.</description>
 </pass>
 </autorouter>
 <elements>
-<element name="C1" library="pie" package="EIA3216" value="2.2 uF TANT" x="20.193" y="8.89" smashed="yes">
-<attribute name="NAME" x="23.368" y="8.255" size="1.27" layer="25" font="vector" ratio="15"/>
-<attribute name="VALUE" x="14.224" y="6.096" size="1.27" layer="27" font="vector" ratio="15"/>
+<element name="C1" library="pie" package="EIA3216" value="2.2 uF TANT" x="22.987" y="8.89" smashed="yes">
+<attribute name="NAME" x="26.416" y="8.255" size="1.27" layer="25" font="vector" ratio="15"/>
+<attribute name="VALUE" x="17.018" y="6.096" size="1.27" layer="27" font="vector" ratio="15"/>
 </element>
-<element name="C2" library="pie" package="EIA3216" value="2.2 uF TANT" x="20.193" y="12.7" smashed="yes" rot="R180">
-<attribute name="NAME" x="23.114" y="12.065" size="1.27" layer="25" font="vector" ratio="15" rot="R180" align="top-right"/>
+<element name="C2" library="pie" package="EIA3216" value="2.2 uF TANT" x="22.987" y="12.7" smashed="yes">
+<attribute name="NAME" x="28.829" y="13.208" size="1.27" layer="25" font="vector" ratio="15" align="top-right"/>
 </element>
 <element name="BATT" library="pie" package="ANDERSON_HORIZONTAL" value="12V" x="9.906" y="12.7" smashed="yes">
 <attribute name="PIE-INT-REF-NUM" value="Anderson" x="9.906" y="12.7" size="1.778" layer="27" display="off"/>
@@ -1176,7 +1176,7 @@ design rules under a new name.</description>
 <attribute name="VALUE" x="69.85" y="34.29" size="1.27" layer="27" font="vector" ratio="15" rot="R270" align="bottom-center"/>
 </element>
 <element name="CAPE" library="SparkFun-Boards" package="BEAGLE_BONE_BLACK_CAPE" value="BEAGLE_BONE_BLACK_CAPE" x="-11.43" y="0" smashed="yes"/>
-<element name="VREG" library="pie" package="TO-220" value="" x="19.05" y="25.4" smashed="yes">
+<element name="VREG" library="pie" package="TO-220" value="LT323A" x="19.05" y="25.4" smashed="yes">
 <attribute name="NAME" x="13.335" y="21.59" size="1.27" layer="25" font="vector" ratio="15" rot="R90"/>
 <attribute name="VALUE" x="27.305" y="27.813" size="1.27" layer="27" font="vector" rot="R90"/>
 </element>
@@ -1224,8 +1224,6 @@ design rules under a new name.</description>
 <signal name="5V">
 <contactref element="C2" pad="C"/>
 <contactref element="VREG" pad="OUT"/>
-<contactref element="CAPE" pad="P9.3"/>
-<contactref element="CAPE" pad="P9.4"/>
 <contactref element="J3" pad="VCC"/>
 <polygon width="0.4064" layer="16" isolate="0.3048">
 <vertex x="0" y="0"/>
@@ -1238,7 +1236,9 @@ design rules under a new name.</description>
 <via x="12.7" y="45.72" extent="1-16" drill="0.6"/>
 <wire x1="11.01" y1="45.72" x2="12.7" y2="45.72" width="0.4064" layer="1"/>
 <wire x1="21.59" y1="16.513" x2="21.59" y2="12.703" width="0.6096" layer="1"/>
-<wire x1="21.59" y1="12.703" x2="21.593" y2="12.7" width="0.6096" layer="1"/>
+<wire x1="21.59" y1="12.703" x2="21.587" y2="12.7" width="0.6096" layer="1"/>
+<contactref element="CAPE" pad="P9.5"/>
+<contactref element="CAPE" pad="P9.6"/>
 </signal>
 <signal name="12V">
 <contactref element="BATT" pad="PIN2"/>
@@ -1246,18 +1246,18 @@ design rules under a new name.</description>
 <contactref element="C1" pad="C"/>
 <contactref element="J2" pad="VCC"/>
 <wire x1="16.51" y1="16.51" x2="16.51" y2="15.367" width="1.524" layer="1"/>
-<wire x1="18.793" y1="8.89" x2="10.287" y2="8.89" width="0.508" layer="1"/>
+<wire x1="21.587" y1="8.89" x2="10.287" y2="8.89" width="0.508" layer="1"/>
 <wire x1="63.5" y1="29.21" x2="60.96" y2="29.21" width="1.524" layer="16"/>
-<wire x1="60.96" y1="29.21" x2="40.64" y2="8.89" width="1.524" layer="16"/>
-<wire x1="40.64" y1="8.89" x2="10.668" y2="8.89" width="1.524" layer="16"/>
 <wire x1="10.287" y1="9.144" x2="16.51" y2="15.367" width="1.524" layer="1"/>
-<wire x1="10.668" y1="8.89" x2="10.033" y2="8.89" width="0.6096" layer="16"/>
+<wire x1="11.938" y1="8.89" x2="10.033" y2="8.89" width="0.6096" layer="16"/>
 <contactref element="BATT" pad="PIN2-LEAD"/>
 <wire x1="10.033" y1="8.89" x2="9.906" y2="8.763" width="0.6096" layer="16"/>
-<wire x1="4.572" y1="8.763" x2="9.906" y2="8.763" width="0" layer="19" extent="1-1"/>
 <wire x1="10.287" y1="8.89" x2="10.287" y2="9.144" width="0.6096" layer="1"/>
 <wire x1="10.287" y1="8.89" x2="10.033" y2="8.89" width="0.6096" layer="1"/>
 <wire x1="10.033" y1="8.89" x2="9.906" y2="8.763" width="0.6096" layer="1"/>
+<wire x1="9.906" y1="8.763" x2="40.513" y2="8.763" width="1.524" layer="16"/>
+<wire x1="40.513" y1="8.763" x2="60.96" y2="29.21" width="1.524" layer="16"/>
+<wire x1="4.572" y1="8.763" x2="9.906" y2="8.763" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="N$1">
 <contactref element="R1" pad="1"/>

--- a/eda/cape.brd
+++ b/eda/cape.brd
@@ -154,7 +154,7 @@ pioners.berkeley.edu/opensource.</text>
 <text x="7.62" y="10.16" size="1.27" layer="27" font="vector" ratio="15" align="bottom-right">12V</text>
 <text x="7.62" y="15.24" size="1.27" layer="27" font="vector" ratio="15" align="top-right">GND</text>
 <text x="71.12" y="17.78" size="0.9144" layer="1" font="vector" ratio="20" rot="R90" align="bottom-center">v1  revB
-3 Oct 2015</text>
+28 Oct 2015</text>
 <hole x="1.524" y="20.701" drill="1.905"/>
 <hole x="3.81" y="20.701" drill="1.905"/>
 <hole x="6.096" y="20.701" drill="1.905"/>

--- a/eda/cape.sch
+++ b/eda/cape.sch
@@ -144,112 +144,21 @@
 A collection of parts and footprints made for the PiE Robotics Competition.&lt;br/&gt;&lt;br/&gt;
 (c) Pioneers in Engineering and Tau Beta Pi CA-A, UC Berkeley.</description>
 <packages>
-<package name="0805">
-<description>Standard US Chip 0805 Footprint</description>
-<wire x1="-0.3" y1="0.6" x2="0.3" y2="0.6" width="0.1524" layer="21"/>
-<wire x1="-0.3" y1="-0.6" x2="0.3" y2="-0.6" width="0.1524" layer="21"/>
-<smd name="1" x="-0.9" y="0" dx="0.8" dy="1.2" layer="1"/>
-<smd name="2" x="0.9" y="0" dx="0.8" dy="1.2" layer="1"/>
-<text x="-1.27" y="1.27" size="1.27" layer="25" font="vector" ratio="10">&gt;NAME</text>
-<text x="-1.27" y="-2.54" size="1.27" layer="27" font="vector">&gt;VALUE</text>
-<rectangle x1="-1.905" y1="-0.762" x2="1.905" y2="0.762" layer="39"/>
-</package>
-<package name="GRM43D">
-<wire x1="2.25" y1="1.6" x2="1.1" y2="1.6" width="0.127" layer="51"/>
-<wire x1="1.1" y1="1.6" x2="-1.1" y2="1.6" width="0.127" layer="51"/>
-<wire x1="-1.1" y1="1.6" x2="-2.25" y2="1.6" width="0.127" layer="51"/>
-<wire x1="-2.25" y1="1.6" x2="-2.25" y2="-1.6" width="0.127" layer="51"/>
-<wire x1="-2.25" y1="-1.6" x2="-1.1" y2="-1.6" width="0.127" layer="51"/>
-<wire x1="-1.1" y1="-1.6" x2="1.1" y2="-1.6" width="0.127" layer="51"/>
-<wire x1="1.1" y1="-1.6" x2="2.25" y2="-1.6" width="0.127" layer="51"/>
-<wire x1="2.25" y1="-1.6" x2="2.25" y2="1.6" width="0.127" layer="51"/>
-<wire x1="1.1" y1="1.6" x2="1.1" y2="-1.6" width="0.127" layer="51"/>
-<wire x1="-1.1" y1="1.6" x2="-1.1" y2="-1.6" width="0.127" layer="51"/>
-<wire x1="-2.3" y1="1.8" x2="2.3" y2="1.8" width="0.127" layer="21"/>
-<wire x1="-2.3" y1="-1.8" x2="2.3" y2="-1.8" width="0.127" layer="21"/>
-<smd name="A" x="1.927" y="0" dx="3.2" dy="1.65" layer="1" rot="R90"/>
-<smd name="C" x="-1.927" y="0" dx="3.2" dy="1.65" layer="1" rot="R90"/>
-<text x="-2.54" y="2.54" size="1.27" layer="25" font="vector" ratio="10">&gt;NAME</text>
-<text x="-2.54" y="-3.81" size="1.27" layer="27" font="vector">&gt;VALUE</text>
-<rectangle x1="-2.2" y1="-1.6" x2="-1.1" y2="1.6" layer="51"/>
-<rectangle x1="1.1" y1="-1.6" x2="2.2" y2="1.6" layer="51"/>
-<rectangle x1="-3.429" y1="-2.159" x2="3.429" y2="2.159" layer="39"/>
-</package>
-<package name="0603-CAP">
-<wire x1="-0.356" y1="0.432" x2="0.356" y2="0.432" width="0.1016" layer="51"/>
-<wire x1="-0.356" y1="-0.419" x2="0.356" y2="-0.419" width="0.1016" layer="51"/>
-<wire x1="0" y1="0.0305" x2="0" y2="-0.0305" width="0.254" layer="21"/>
-<smd name="1" x="-0.85" y="0" dx="1.1" dy="1" layer="1"/>
-<smd name="2" x="0.85" y="0" dx="1.1" dy="1" layer="1"/>
-<text x="-1.27" y="1.27" size="1.27" layer="25" font="vector" ratio="10">&gt;NAME</text>
-<text x="-1.27" y="-2.54" size="1.27" layer="27" font="vector">&gt;VALUE</text>
-<rectangle x1="-0.8382" y1="-0.4699" x2="-0.3381" y2="0.4801" layer="51"/>
-<rectangle x1="0.3302" y1="-0.4699" x2="0.8303" y2="0.4801" layer="51"/>
-<rectangle x1="-0.1999" y1="-0.3" x2="0.1999" y2="0.3" layer="35"/>
-<rectangle x1="-2.032" y1="-0.635" x2="2.032" y2="0.635" layer="39"/>
-</package>
-<package name="0402-CAP">
-<description>&lt;b&gt;CAPACITOR&lt;/b&gt;&lt;p&gt;
-chip</description>
-<wire x1="-0.245" y1="0.224" x2="0.245" y2="0.224" width="0.1524" layer="51"/>
-<wire x1="0.245" y1="-0.224" x2="-0.245" y2="-0.224" width="0.1524" layer="51"/>
-<wire x1="0" y1="0.0305" x2="0" y2="-0.0305" width="0.4064" layer="21"/>
-<smd name="1" x="-0.65" y="0" dx="0.7" dy="0.9" layer="1"/>
-<smd name="2" x="0.65" y="0" dx="0.7" dy="0.9" layer="1"/>
-<text x="-1.27" y="1.27" size="1.27" layer="25" font="vector" ratio="10">&gt;NAME</text>
-<text x="-1.27" y="-2.54" size="1.27" layer="27" font="vector">&gt;VALUE</text>
-<rectangle x1="-0.554" y1="-0.3048" x2="-0.254" y2="0.2951" layer="51"/>
-<rectangle x1="0.2588" y1="-0.3048" x2="0.5588" y2="0.2951" layer="51"/>
-<rectangle x1="-0.1999" y1="-0.3" x2="0.1999" y2="0.3" layer="35"/>
-<rectangle x1="-1.651" y1="-0.635" x2="1.651" y2="0.635" layer="39"/>
-</package>
-<package name="1210">
-<wire x1="-1.6" y1="1.3" x2="1.6" y2="1.3" width="0.127" layer="51"/>
-<wire x1="1.6" y1="1.3" x2="1.6" y2="-1.3" width="0.127" layer="51"/>
-<wire x1="1.6" y1="-1.3" x2="-1.6" y2="-1.3" width="0.127" layer="51"/>
-<wire x1="-1.6" y1="-1.3" x2="-1.6" y2="1.3" width="0.127" layer="51"/>
-<wire x1="-1.6" y1="1.3" x2="1.6" y2="1.3" width="0.2032" layer="21"/>
-<wire x1="-1.6" y1="-1.3" x2="1.6" y2="-1.3" width="0.2032" layer="21"/>
-<smd name="1" x="-1.6" y="0" dx="1.2" dy="2" layer="1"/>
-<smd name="2" x="1.6" y="0" dx="1.2" dy="2" layer="1"/>
-<text x="-1.9049" y="1.9097" size="1.27" layer="25" font="vector" ratio="10">&gt;NAME</text>
-<text x="-1.9033" y="-3.1765" size="1.27" layer="27" font="vector">&gt;VALUE</text>
-<rectangle x1="-2.794" y1="-1.651" x2="2.794" y2="1.651" layer="39"/>
-</package>
-<package name="1206">
-<wire x1="-0.965" y1="0.787" x2="0.965" y2="0.787" width="0.1016" layer="51"/>
-<wire x1="-0.965" y1="-0.787" x2="0.965" y2="-0.787" width="0.1016" layer="51"/>
-<smd name="1" x="-1.4" y="0" dx="1.6" dy="1.8" layer="1"/>
-<smd name="2" x="1.4" y="0" dx="1.6" dy="1.8" layer="1"/>
-<text x="-1.905" y="1.27" size="1.27" layer="25" font="vector" ratio="10">&gt;NAME</text>
-<text x="-1.905" y="-2.54" size="1.27" layer="27" font="vector">&gt;VALUE</text>
-<rectangle x1="-1.7018" y1="-0.8509" x2="-0.9517" y2="0.8491" layer="51"/>
-<rectangle x1="0.9517" y1="-0.8491" x2="1.7018" y2="0.8509" layer="51"/>
-<rectangle x1="-0.1999" y1="-0.4001" x2="0.1999" y2="0.4001" layer="35"/>
-<rectangle x1="-2.794" y1="-1.016" x2="2.794" y2="1.016" layer="39"/>
-</package>
-<package name="CTZ3">
-<description>CTZ3 Series land pattern for variable capacitor - CTZ3E-50C-W1-PF</description>
-<wire x1="-1.6" y1="1.4" x2="-1.6" y2="-2.25" width="0.127" layer="51"/>
-<wire x1="-1.6" y1="-2.25" x2="1.6" y2="-2.25" width="0.127" layer="51"/>
-<wire x1="1.6" y1="1.4" x2="1.6" y2="-2.25" width="0.127" layer="51"/>
-<wire x1="-0.5" y1="0" x2="0.5" y2="0" width="0.127" layer="51"/>
-<wire x1="-1.6" y1="1.4" x2="-1" y2="2.2" width="0.127" layer="51"/>
-<wire x1="1.6" y1="1.4" x2="1" y2="2.2" width="0.127" layer="51"/>
-<wire x1="-1" y1="2.2" x2="1" y2="2.2" width="0.127" layer="51"/>
-<wire x1="0" y1="0.8" x2="0" y2="-0.8" width="0.127" layer="51"/>
-<wire x1="-0.8" y1="0" x2="0.8" y2="0" width="0.127" layer="51"/>
-<wire x1="-1.05" y1="2.25" x2="-1.7" y2="1.45" width="0.127" layer="21"/>
-<wire x1="-1.7" y1="1.45" x2="-1.7" y2="-2.35" width="0.127" layer="21"/>
-<wire x1="-1.7" y1="-2.35" x2="-1.05" y2="-2.35" width="0.127" layer="21"/>
-<wire x1="1.05" y1="2.25" x2="1.7" y2="1.4" width="0.127" layer="21"/>
-<wire x1="1.7" y1="1.4" x2="1.7" y2="-2.35" width="0.127" layer="21"/>
-<wire x1="1.7" y1="-2.35" x2="1.05" y2="-2.35" width="0.127" layer="21"/>
-<smd name="+" x="0" y="2.05" dx="1.5" dy="1.2" layer="1"/>
-<smd name="-" x="0" y="-2.05" dx="1.5" dy="1.2" layer="1"/>
-<text x="-2.5428" y="-2.5334" size="1.27" layer="25" font="vector" ratio="10" rot="R90">&gt;NAME</text>
-<text x="3.8064" y="-2.5334" size="1.27" layer="27" font="vector" rot="R90">&gt;VALUE</text>
-<rectangle x1="-2.032" y1="-2.794" x2="2.032" y2="2.794" layer="39"/>
+<package name="EIA3216">
+<wire x1="-1" y1="-1.2" x2="-2.5" y2="-1.2" width="0.2032" layer="21"/>
+<wire x1="-2.5" y1="-1.2" x2="-2.5" y2="1.2" width="0.2032" layer="21"/>
+<wire x1="-2.5" y1="1.2" x2="-1" y2="1.2" width="0.2032" layer="21"/>
+<wire x1="1" y1="-1.2" x2="2.1" y2="-1.2" width="0.2032" layer="21"/>
+<wire x1="2.1" y1="-1.2" x2="2.5" y2="-0.8" width="0.2032" layer="21"/>
+<wire x1="2.5" y1="-0.8" x2="2.5" y2="0.8" width="0.2032" layer="21"/>
+<wire x1="2.5" y1="0.8" x2="2.1" y2="1.2" width="0.2032" layer="21"/>
+<wire x1="2.1" y1="1.2" x2="1" y2="1.2" width="0.2032" layer="21"/>
+<wire x1="0.381" y1="1.016" x2="0.381" y2="-1.016" width="0.127" layer="21"/>
+<smd name="C" x="-1.4" y="0" dx="1.6" dy="1.4" layer="1" rot="R90"/>
+<smd name="A" x="1.4" y="0" dx="1.6" dy="1.4" layer="1" rot="R90"/>
+<text x="-2.54" y="1.905" size="1.27" layer="25" font="vector" ratio="10">&gt;NAME</text>
+<text x="-2.54" y="-3.175" size="1.27" layer="27" font="vector" ratio="10">&gt;VALUE</text>
+<rectangle x1="-3.175" y1="-1.524" x2="3.175" y2="1.524" layer="39"/>
 </package>
 <package name="ANDERSON_HORIZONTAL">
 <description>2-pin 25A Anderson Connector
@@ -2337,6 +2246,415 @@ Source: http://www.murata.com .. GRM43DR72E224KW01.pdf</description>
 <vertex x="3.429" y="0" curve="-90"/>
 </polygon>
 </package>
+<package name="EIA3528">
+<wire x1="-0.9" y1="-1.6" x2="-2.6" y2="-1.6" width="0.2032" layer="21"/>
+<wire x1="-2.6" y1="-1.6" x2="-2.6" y2="1.55" width="0.2032" layer="21"/>
+<wire x1="-2.6" y1="1.55" x2="-0.9" y2="1.55" width="0.2032" layer="21"/>
+<wire x1="1" y1="-1.55" x2="2.2" y2="-1.55" width="0.2032" layer="21"/>
+<wire x1="2.2" y1="-1.55" x2="2.6" y2="-1.2" width="0.2032" layer="51"/>
+<wire x1="2.6" y1="-1.2" x2="2.6" y2="1.25" width="0.2032" layer="21"/>
+<wire x1="2.6" y1="1.25" x2="2.2" y2="1.55" width="0.2032" layer="51"/>
+<wire x1="2.2" y1="1.55" x2="1" y2="1.55" width="0.2032" layer="21"/>
+<wire x1="0.609" y1="1.311" x2="0.609" y2="-1.286" width="0.2032" layer="21" style="longdash"/>
+<smd name="C" x="-1.65" y="0" dx="2.5" dy="1.2" layer="1" rot="R90"/>
+<smd name="A" x="1.65" y="0" dx="2.5" dy="1.2" layer="1" rot="R90"/>
+<text x="-2.54" y="1.905" size="1.27" layer="25" font="vector" ratio="10">&gt;NAME</text>
+<text x="-2.54" y="-3.175" size="1.27" layer="27" font="fixed">&gt;VALUE</text>
+<rectangle x1="-3.175" y1="-1.905" x2="3.175" y2="1.905" layer="39"/>
+</package>
+<package name="EIA7343">
+<wire x1="-5" y1="2.5" x2="-2" y2="2.5" width="0.2032" layer="21"/>
+<wire x1="-5" y1="2.5" x2="-5" y2="-2.5" width="0.2032" layer="21"/>
+<wire x1="-5" y1="-2.5" x2="-2" y2="-2.5" width="0.2032" layer="21"/>
+<wire x1="2" y1="2.5" x2="4" y2="2.5" width="0.2032" layer="21"/>
+<wire x1="4" y1="2.5" x2="5" y2="1.5" width="0.2032" layer="21"/>
+<wire x1="5" y1="1.5" x2="5" y2="-1.5" width="0.2032" layer="21"/>
+<wire x1="5" y1="-1.5" x2="4" y2="-2.5" width="0.2032" layer="21"/>
+<wire x1="4" y1="-2.5" x2="2" y2="-2.5" width="0.2032" layer="21"/>
+<smd name="C" x="-3.17" y="0" dx="2.55" dy="2.7" layer="1" rot="R180"/>
+<smd name="A" x="3.17" y="0" dx="2.55" dy="2.7" layer="1" rot="R180"/>
+<text x="-5.08" y="3.175" size="1.27" layer="25" font="vector" ratio="10">&gt;NAME</text>
+<text x="-5.08" y="-4.445" size="1.27" layer="27" font="vector">&gt;VALUE</text>
+<rectangle x1="-5.588" y1="-2.794" x2="5.588" y2="2.794" layer="39"/>
+</package>
+<package name="PANASONIC_G">
+<description>&lt;b&gt;Panasonic Aluminium Electrolytic Capacitor VS-Serie Package G&lt;/b&gt;</description>
+<wire x1="-5.1" y1="5.1" x2="2.8" y2="5.1" width="0.1016" layer="51"/>
+<wire x1="2.8" y1="5.1" x2="5.1" y2="2.8" width="0.1016" layer="51"/>
+<wire x1="5.1" y1="2.8" x2="5.1" y2="-2.8" width="0.1016" layer="51"/>
+<wire x1="5.1" y1="-2.8" x2="2.8" y2="-5.1" width="0.1016" layer="51"/>
+<wire x1="2.8" y1="-5.1" x2="-5.1" y2="-5.1" width="0.1016" layer="51"/>
+<wire x1="-5.1" y1="-5.1" x2="-5.1" y2="5.1" width="0.1016" layer="51"/>
+<wire x1="-5.1" y1="1.635" x2="-5.1" y2="5.1" width="0.2032" layer="21"/>
+<wire x1="-5.1" y1="5.1" x2="2.8" y2="5.1" width="0.2032" layer="21"/>
+<wire x1="2.8" y1="5.1" x2="5.1" y2="2.8" width="0.2032" layer="21"/>
+<wire x1="5.1" y1="2.8" x2="5.1" y2="1.635" width="0.2032" layer="21"/>
+<wire x1="5.1" y1="-1.635" x2="5.1" y2="-2.8" width="0.2032" layer="21"/>
+<wire x1="5.1" y1="-2.8" x2="2.8" y2="-5.1" width="0.2032" layer="21"/>
+<wire x1="2.8" y1="-5.1" x2="-5.1" y2="-5.1" width="0.2032" layer="21"/>
+<wire x1="-5.1" y1="-5.1" x2="-5.1" y2="-1.635" width="0.2032" layer="21"/>
+<wire x1="-4.85" y1="-1" x2="4.85" y2="-1" width="0.2032" layer="21" curve="156.699401" cap="flat"/>
+<wire x1="-4.85" y1="1" x2="4.85" y2="1" width="0.2032" layer="21" curve="-156.699401" cap="flat"/>
+<wire x1="-3.25" y1="3.7" x2="-3.25" y2="-3.65" width="0.1016" layer="51"/>
+<circle x="0" y="0" radius="4.95" width="0.1016" layer="51"/>
+<smd name="-" x="-4.35" y="0" dx="4.1" dy="1.6" layer="1"/>
+<smd name="+" x="4.35" y="0" dx="4.1" dy="1.6" layer="1"/>
+<text x="-5.08" y="5.715" size="1.27" layer="25" font="vector" ratio="10">&gt;NAME</text>
+<text x="-5.08" y="-6.985" size="1.27" layer="27" font="vector">&gt;VALUE</text>
+<rectangle x1="-5.85" y1="-0.45" x2="-4.9" y2="0.45" layer="51"/>
+<rectangle x1="4.9" y1="-0.45" x2="5.85" y2="0.45" layer="51"/>
+<polygon width="0.1016" layer="51">
+<vertex x="-3.3" y="3.6"/>
+<vertex x="-4.05" y="2.75"/>
+<vertex x="-4.65" y="1.55"/>
+<vertex x="-4.85" y="0.45"/>
+<vertex x="-4.85" y="-0.45"/>
+<vertex x="-4.65" y="-1.55"/>
+<vertex x="-4.05" y="-2.75"/>
+<vertex x="-3.3" y="-3.6"/>
+<vertex x="-3.3" y="3.55"/>
+</polygon>
+<polygon width="0.127" layer="39" spacing="25.4" pour="hatch">
+<vertex x="-5.461" y="5.461"/>
+<vertex x="-5.461" y="0.889"/>
+<vertex x="-6.477" y="0.889"/>
+<vertex x="-6.477" y="-0.889"/>
+<vertex x="-5.461" y="-0.889"/>
+<vertex x="-5.461" y="-5.461"/>
+<vertex x="3.048" y="-5.461"/>
+<vertex x="5.588" y="-2.921"/>
+<vertex x="5.588" y="-0.889"/>
+<vertex x="6.477" y="-0.889"/>
+<vertex x="6.477" y="0.889"/>
+<vertex x="5.588" y="0.889"/>
+<vertex x="5.588" y="2.921"/>
+<vertex x="3.048" y="5.461"/>
+</polygon>
+</package>
+<package name="PANASONIC_E">
+<description>&lt;b&gt;Panasonic Aluminium Electrolytic Capacitor VS-Serie Package E&lt;/b&gt;</description>
+<wire x1="-4.1" y1="4.1" x2="1.8" y2="4.1" width="0.1016" layer="51"/>
+<wire x1="1.8" y1="4.1" x2="4.1" y2="1.8" width="0.1016" layer="51"/>
+<wire x1="4.1" y1="1.8" x2="4.1" y2="-1.8" width="0.1016" layer="51"/>
+<wire x1="4.1" y1="-1.8" x2="1.8" y2="-4.1" width="0.1016" layer="51"/>
+<wire x1="1.8" y1="-4.1" x2="-4.1" y2="-4.1" width="0.1016" layer="51"/>
+<wire x1="-4.1" y1="-4.1" x2="-4.1" y2="4.1" width="0.1016" layer="51"/>
+<wire x1="-4.1" y1="0.9508" x2="-4.1" y2="4.1" width="0.2032" layer="21"/>
+<wire x1="-4.1" y1="4.1" x2="1.8" y2="4.1" width="0.2032" layer="21"/>
+<wire x1="1.8" y1="4.1" x2="4.1" y2="1.8" width="0.2032" layer="21"/>
+<wire x1="4.1" y1="1.8" x2="4.1" y2="0.9254" width="0.2032" layer="21"/>
+<wire x1="4.1" y1="-0.9254" x2="4.1" y2="-1.8" width="0.2032" layer="21"/>
+<wire x1="4.1" y1="-1.8" x2="1.8" y2="-4.1" width="0.2032" layer="21"/>
+<wire x1="1.8" y1="-4.1" x2="-4.1" y2="-4.1" width="0.2032" layer="21"/>
+<wire x1="-4.1" y1="-4.1" x2="-4.1" y2="-0.9254" width="0.2032" layer="21"/>
+<wire x1="-2.2" y1="3.25" x2="-2.2" y2="-3.25" width="0.1016" layer="51"/>
+<wire x1="-3.85" y1="0.9" x2="3.85" y2="0.9" width="0.2032" layer="21" curve="-153.684915" cap="flat"/>
+<wire x1="-3.85" y1="-0.9" x2="3.85" y2="-0.9" width="0.2032" layer="21" curve="153.684915" cap="flat"/>
+<circle x="0" y="0" radius="3.95" width="0.1016" layer="51"/>
+<smd name="-" x="-3" y="0" dx="3.8" dy="1.4" layer="1"/>
+<smd name="+" x="3" y="0" dx="3.8" dy="1.4" layer="1"/>
+<text x="-3.81" y="4.445" size="1.27" layer="25" font="vector" ratio="10">&gt;NAME</text>
+<text x="-3.81" y="-5.715" size="1.27" layer="27" font="vector">&gt;VALUE</text>
+<rectangle x1="-4.5" y1="-0.35" x2="-3.8" y2="0.35" layer="51"/>
+<rectangle x1="3.8" y1="-0.35" x2="4.5" y2="0.35" layer="51"/>
+<polygon width="0.1016" layer="51">
+<vertex x="-2.25" y="3.2"/>
+<vertex x="-3" y="2.5"/>
+<vertex x="-3.6" y="1.5"/>
+<vertex x="-3.85" y="0.65"/>
+<vertex x="-3.85" y="-0.65"/>
+<vertex x="-3.55" y="-1.6"/>
+<vertex x="-2.95" y="-2.55"/>
+<vertex x="-2.25" y="-3.2"/>
+<vertex x="-2.25" y="3.15"/>
+</polygon>
+<polygon width="0.127" layer="39" spacing="25.4" pour="hatch">
+<vertex x="-4.445" y="4.445"/>
+<vertex x="-4.445" y="0.889"/>
+<vertex x="-4.953" y="0.889"/>
+<vertex x="-4.953" y="-0.889"/>
+<vertex x="-4.445" y="-0.889"/>
+<vertex x="-4.445" y="-4.445"/>
+<vertex x="2.032" y="-4.445"/>
+<vertex x="4.572" y="-1.905"/>
+<vertex x="4.572" y="-0.889"/>
+<vertex x="4.953" y="-0.889"/>
+<vertex x="4.953" y="0.889"/>
+<vertex x="4.572" y="0.889"/>
+<vertex x="4.572" y="1.905"/>
+<vertex x="2.032" y="4.445"/>
+</polygon>
+</package>
+<package name="PANASONIC_C">
+<description>&lt;b&gt;Panasonic Aluminium Electrolytic Capacitor VS-Serie Package E&lt;/b&gt;</description>
+<wire x1="-2.6" y1="2.45" x2="1.6" y2="2.45" width="0.2032" layer="21"/>
+<wire x1="1.6" y1="2.45" x2="2.7" y2="1.35" width="0.2032" layer="21"/>
+<wire x1="2.7" y1="-1.75" x2="1.6" y2="-2.85" width="0.2032" layer="21"/>
+<wire x1="1.6" y1="-2.85" x2="-2.6" y2="-2.85" width="0.2032" layer="21"/>
+<wire x1="-2.6" y1="2.45" x2="1.6" y2="2.45" width="0.1016" layer="51"/>
+<wire x1="1.6" y1="2.45" x2="2.7" y2="1.35" width="0.1016" layer="51"/>
+<wire x1="2.7" y1="-1.75" x2="1.6" y2="-2.85" width="0.1016" layer="51"/>
+<wire x1="1.6" y1="-2.85" x2="-2.6" y2="-2.85" width="0.1016" layer="51"/>
+<wire x1="-2.6" y1="2.45" x2="-2.6" y2="0.35" width="0.2032" layer="21"/>
+<wire x1="-2.6" y1="-2.85" x2="-2.6" y2="-0.75" width="0.2032" layer="21"/>
+<wire x1="2.7" y1="1.35" x2="2.7" y2="0.4262" width="0.2032" layer="21"/>
+<wire x1="2.7" y1="-1.75" x2="2.7" y2="-0.827" width="0.2032" layer="21"/>
+<wire x1="-2.6" y1="2.45" x2="-2.6" y2="-2.85" width="0.1016" layer="51"/>
+<wire x1="2.7" y1="1.35" x2="2.7" y2="-1.75" width="0.1016" layer="51"/>
+<wire x1="-2.4" y1="0.35" x2="2.5008" y2="0.427" width="0.2032" layer="21" curve="-156.699401"/>
+<wire x1="2.5" y1="-0.827" x2="-2.4" y2="-0.75" width="0.2032" layer="21" curve="-154.694887"/>
+<circle x="0.05" y="-0.2" radius="2.5004" width="0.1016" layer="51"/>
+<smd name="-" x="-1.8" y="-0.2" dx="2.2" dy="0.65" layer="1"/>
+<smd name="+" x="1.9" y="-0.2" dx="2.2" dy="0.65" layer="1"/>
+<text x="-2.54" y="3.175" size="1.27" layer="25" font="vector" ratio="10">&gt;NAME</text>
+<text x="-2.54" y="-4.445" size="1.27" layer="27" font="vector">&gt;VALUE</text>
+<polygon width="0.127" layer="39" spacing="25.4" pour="hatch">
+<vertex x="-2.921" y="2.794"/>
+<vertex x="-2.921" y="0.254"/>
+<vertex x="-3.048" y="0.254"/>
+<vertex x="-3.048" y="-0.635"/>
+<vertex x="-2.921" y="-0.635"/>
+<vertex x="-2.921" y="-3.175"/>
+<vertex x="1.778" y="-3.175"/>
+<vertex x="3.048" y="-1.905"/>
+<vertex x="3.048" y="-0.635"/>
+<vertex x="3.175" y="-0.635"/>
+<vertex x="3.175" y="0.254"/>
+<vertex x="3.048" y="0.254"/>
+<vertex x="3.048" y="1.524"/>
+<vertex x="1.778" y="2.794"/>
+</polygon>
+</package>
+<package name="NIPPON_F80">
+<wire x1="-3.3" y1="3.3" x2="1.7" y2="3.3" width="0.2032" layer="21"/>
+<wire x1="1.7" y1="3.3" x2="3.3" y2="2" width="0.2032" layer="21"/>
+<wire x1="3.3" y1="-2" x2="1.7" y2="-3.3" width="0.2032" layer="21"/>
+<wire x1="1.7" y1="-3.3" x2="-3.3" y2="-3.3" width="0.2032" layer="21"/>
+<wire x1="-3.3" y1="3.3" x2="1.7" y2="3.3" width="0.1016" layer="51"/>
+<wire x1="1.7" y1="3.3" x2="3.3" y2="2" width="0.1016" layer="51"/>
+<wire x1="3.3" y1="-2" x2="1.7" y2="-3.3" width="0.1016" layer="51"/>
+<wire x1="1.7" y1="-3.3" x2="-3.3" y2="-3.3" width="0.1016" layer="51"/>
+<wire x1="-3.3" y1="3.3" x2="-3.3" y2="0.812" width="0.2032" layer="21"/>
+<wire x1="-3.3" y1="-3.3" x2="-3.3" y2="-0.812" width="0.2032" layer="21"/>
+<wire x1="3.3" y1="2" x2="3.3" y2="0.812" width="0.2032" layer="21"/>
+<wire x1="3.3" y1="-2" x2="3.3" y2="-0.812" width="0.2032" layer="21"/>
+<wire x1="-3.3" y1="3.3" x2="-3.3" y2="-3.3" width="0.1016" layer="51"/>
+<wire x1="3.3" y1="2" x2="3.3" y2="-2" width="0.1016" layer="51"/>
+<circle x="0" y="0" radius="3.15" width="0.1016" layer="51"/>
+<smd name="-" x="-2.4" y="0" dx="2.95" dy="1" layer="1"/>
+<smd name="+" x="2.4" y="0" dx="2.95" dy="1" layer="1"/>
+<text x="-3.175" y="3.81" size="0.4064" layer="25" font="vector" ratio="10">&gt;NAME</text>
+<text x="-3.175" y="-4.445" size="0.4064" layer="27" font="vector">&gt;VALUE</text>
+<wire x1="1.651" y1="-3.683" x2="1.905" y2="-3.683" width="0.127" layer="39"/>
+<wire x1="3.683" y1="-2.286" x2="3.683" y2="-2.032" width="0.127" layer="39"/>
+<polygon width="0.127" layer="39" spacing="25.4" pour="hatch">
+<vertex x="-3.683" y="3.683"/>
+<vertex x="-3.683" y="0.635"/>
+<vertex x="-3.937" y="0.635"/>
+<vertex x="-3.937" y="-0.635"/>
+<vertex x="-3.683" y="-0.635"/>
+<vertex x="-3.683" y="-3.683"/>
+<vertex x="1.905" y="-3.683"/>
+<vertex x="3.683" y="-2.286"/>
+<vertex x="3.683" y="-0.635"/>
+<vertex x="3.937" y="-0.635"/>
+<vertex x="3.937" y="0.635"/>
+<vertex x="3.683" y="0.635"/>
+<vertex x="3.683" y="2.286"/>
+<vertex x="1.905" y="3.683"/>
+</polygon>
+<wire x1="-3.048" y1="0.889" x2="3.048" y2="0.889" width="0.2032" layer="21" curve="-147.479591"/>
+<wire x1="3.048" y1="-0.889" x2="-3.048" y2="-0.889" width="0.2032" layer="21" curve="-147.479591"/>
+</package>
+<package name="PANASONIC_D">
+<wire x1="-3.25" y1="3.25" x2="1.55" y2="3.25" width="0.1016" layer="51"/>
+<wire x1="1.55" y1="3.25" x2="3.25" y2="1.55" width="0.1016" layer="51"/>
+<wire x1="3.25" y1="1.55" x2="3.25" y2="-1.55" width="0.1016" layer="51"/>
+<wire x1="3.25" y1="-1.55" x2="1.55" y2="-3.25" width="0.1016" layer="51"/>
+<wire x1="1.55" y1="-3.25" x2="-3.25" y2="-3.25" width="0.1016" layer="51"/>
+<wire x1="-3.25" y1="-3.25" x2="-3.25" y2="3.25" width="0.1016" layer="51"/>
+<wire x1="-3.25" y1="0.95" x2="-3.25" y2="3.25" width="0.1016" layer="21"/>
+<wire x1="-3.25" y1="3.25" x2="1.55" y2="3.25" width="0.1016" layer="21"/>
+<wire x1="1.55" y1="3.25" x2="3.25" y2="1.55" width="0.1016" layer="21"/>
+<wire x1="3.25" y1="1.55" x2="3.25" y2="0.95" width="0.1016" layer="21"/>
+<wire x1="3.25" y1="-0.95" x2="3.25" y2="-1.55" width="0.1016" layer="21"/>
+<wire x1="3.25" y1="-1.55" x2="1.55" y2="-3.25" width="0.1016" layer="21"/>
+<wire x1="1.55" y1="-3.25" x2="-3.25" y2="-3.25" width="0.1016" layer="21"/>
+<wire x1="-3.25" y1="-3.25" x2="-3.25" y2="-0.95" width="0.1016" layer="21"/>
+<wire x1="2.95" y1="0.95" x2="-2.95" y2="0.95" width="0.1016" layer="21" curve="144.299363"/>
+<wire x1="-2.95" y1="-0.95" x2="2.95" y2="-0.95" width="0.1016" layer="21" curve="144.299363"/>
+<wire x1="-2.1" y1="2.25" x2="-2.1" y2="-2.2" width="0.1016" layer="51"/>
+<circle x="0" y="0" radius="3.1" width="0.1016" layer="51"/>
+<smd name="+" x="2.4" y="0" dx="3" dy="1.4" layer="1"/>
+<smd name="-" x="-2.4" y="0" dx="3" dy="1.4" layer="1"/>
+<text x="-3.175" y="3.81" size="1.27" layer="25" font="vector" ratio="10">&gt;NAME</text>
+<text x="-3.175" y="-5.08" size="1.27" layer="27" font="vector">&gt;VALUE</text>
+<rectangle x1="-3.65" y1="-0.35" x2="-3.05" y2="0.35" layer="51"/>
+<rectangle x1="3.05" y1="-0.35" x2="3.65" y2="0.35" layer="51"/>
+<polygon width="0.1016" layer="51">
+<vertex x="-2.15" y="2.15"/>
+<vertex x="-2.6" y="1.6"/>
+<vertex x="-2.9" y="0.9"/>
+<vertex x="-3.05" y="0"/>
+<vertex x="-2.9" y="-0.95"/>
+<vertex x="-2.55" y="-1.65"/>
+<vertex x="-2.15" y="-2.15"/>
+<vertex x="-2.15" y="2.1"/>
+</polygon>
+<polygon width="0.127" layer="39" spacing="25.4" pour="hatch">
+<vertex x="-3.556" y="3.556"/>
+<vertex x="-3.556" y="0.889"/>
+<vertex x="-4.064" y="0.889"/>
+<vertex x="-4.064" y="-0.889"/>
+<vertex x="-3.556" y="-0.889"/>
+<vertex x="-3.556" y="-3.556"/>
+<vertex x="1.778" y="-3.556"/>
+<vertex x="3.683" y="-1.651"/>
+<vertex x="3.683" y="-0.889"/>
+<vertex x="4.064" y="-0.889"/>
+<vertex x="4.064" y="0.762"/>
+<vertex x="4.064" y="0.889"/>
+<vertex x="3.683" y="0.889"/>
+<vertex x="3.683" y="1.651"/>
+<vertex x="1.778" y="3.556"/>
+</polygon>
+</package>
+<package name="VISHAY_C">
+<wire x1="0" y1="1.27" x2="0" y2="1.905" width="0.254" layer="21"/>
+<wire x1="-2.0574" y1="4.2926" x2="-2.0574" y2="-4.2926" width="0.127" layer="21"/>
+<wire x1="-2.0574" y1="-4.2926" x2="2.0574" y2="-4.2926" width="0.127" layer="21"/>
+<wire x1="2.0574" y1="-4.2926" x2="2.0574" y2="4.2926" width="0.127" layer="21"/>
+<wire x1="2.0574" y1="4.2926" x2="-2.0574" y2="4.2926" width="0.127" layer="21"/>
+<smd name="+" x="0" y="3.048" dx="3.556" dy="1.778" layer="1"/>
+<smd name="-" x="0" y="-3.048" dx="3.556" dy="1.778" layer="1"/>
+<text x="-2.54" y="-4.445" size="1.27" layer="25" font="vector" ratio="10" rot="R90">&gt;NAME</text>
+<text x="3.81" y="-4.445" size="1.27" layer="27" font="vector" rot="R90">&gt;VALUE</text>
+<rectangle x1="-2.286" y1="-4.572" x2="2.286" y2="4.572" layer="39"/>
+</package>
+<package name="PANASONIC_H13">
+<wire x1="-6.75" y1="6.75" x2="4" y2="6.75" width="0.1016" layer="51"/>
+<wire x1="4" y1="6.75" x2="6.75" y2="4" width="0.1016" layer="51"/>
+<wire x1="6.75" y1="4" x2="6.75" y2="-4" width="0.1016" layer="51"/>
+<wire x1="6.75" y1="-4" x2="4" y2="-6.75" width="0.1016" layer="51"/>
+<wire x1="4" y1="-6.75" x2="-6.75" y2="-6.75" width="0.1016" layer="51"/>
+<wire x1="-6.75" y1="-6.75" x2="-6.75" y2="6.75" width="0.1016" layer="51"/>
+<wire x1="-6.75" y1="1.0254" x2="-6.75" y2="6.75" width="0.2032" layer="21"/>
+<wire x1="-6.75" y1="6.75" x2="4" y2="6.75" width="0.2032" layer="21"/>
+<wire x1="4" y1="6.75" x2="6.75" y2="4" width="0.2032" layer="21"/>
+<wire x1="6.75" y1="4" x2="6.75" y2="1.0254" width="0.2032" layer="21"/>
+<wire x1="6.75" y1="-1.0254" x2="6.75" y2="-4" width="0.2032" layer="21"/>
+<wire x1="6.75" y1="-4" x2="4" y2="-6.75" width="0.2032" layer="21"/>
+<wire x1="4" y1="-6.75" x2="-6.75" y2="-6.75" width="0.2032" layer="21"/>
+<wire x1="-6.75" y1="-6.75" x2="-6.75" y2="-1.0254" width="0.2032" layer="21"/>
+<wire x1="-6.55" y1="-1.2" x2="6.45" y2="-1.2" width="0.2032" layer="21" curve="156.692742" cap="flat"/>
+<wire x1="-6.55" y1="1.2" x2="6.55" y2="1.2" width="0.2032" layer="21" curve="-156.697982" cap="flat"/>
+<wire x1="-5" y1="4.25" x2="-4.95" y2="-4.35" width="0.1016" layer="51"/>
+<circle x="0" y="0" radius="6.6" width="0.1016" layer="51"/>
+<smd name="-" x="-4.7" y="0" dx="5" dy="1.6" layer="1"/>
+<smd name="+" x="4.7" y="0" dx="5" dy="1.6" layer="1"/>
+<text x="-6.35" y="7.62" size="1.27" layer="25" font="vector" ratio="10">&gt;NAME</text>
+<text x="-6.35" y="-8.89" size="1.27" layer="27" font="vector">&gt;VALUE</text>
+<rectangle x1="-7.55" y1="-0.45" x2="-6.6" y2="0.45" layer="51"/>
+<rectangle x1="6.6" y1="-0.45" x2="7.55" y2="0.45" layer="51"/>
+<polygon width="0.1016" layer="51">
+<vertex x="-5" y="4.2"/>
+<vertex x="-5.75" y="3.15"/>
+<vertex x="-6.25" y="2.05"/>
+<vertex x="-6.55" y="0.45"/>
+<vertex x="-6.55" y="-0.45"/>
+<vertex x="-6.35" y="-1.65"/>
+<vertex x="-5.75" y="-3.25"/>
+<vertex x="-5" y="-4.2"/>
+</polygon>
+<polygon width="0.127" layer="39" spacing="25.4" pour="hatch">
+<vertex x="-7.112" y="7.112"/>
+<vertex x="-7.112" y="1.016"/>
+<vertex x="-7.62" y="1.016"/>
+<vertex x="-7.62" y="-1.016"/>
+<vertex x="-7.112" y="-1.016"/>
+<vertex x="-7.112" y="-7.112"/>
+<vertex x="4.191" y="-7.112"/>
+<vertex x="7.239" y="-4.064"/>
+<vertex x="7.239" y="-1.016"/>
+<vertex x="7.62" y="-1.016"/>
+<vertex x="7.62" y="1.016"/>
+<vertex x="7.239" y="1.016"/>
+<vertex x="7.239" y="4.064"/>
+<vertex x="4.191" y="7.112"/>
+</polygon>
+</package>
+<package name="EIA6032">
+<wire x1="-2.8" y1="-1.6" x2="3.2" y2="-1.6" width="0.127" layer="21"/>
+<wire x1="3.2" y1="1.6" x2="-2.8" y2="1.6" width="0.127" layer="21"/>
+<wire x1="-2.8" y1="1.6" x2="-3.4" y2="1" width="0.127" layer="51"/>
+<wire x1="-3.4" y1="1" x2="-3.4" y2="-1" width="0.127" layer="21"/>
+<wire x1="-2.8" y1="-1.6" x2="-3.4" y2="-1" width="0.127" layer="51"/>
+<smd name="P$1" x="-2.3" y="0" dx="1.5" dy="2.4" layer="1"/>
+<smd name="P$2" x="2.3" y="0" dx="1.5" dy="2.4" layer="1"/>
+<text x="-3.175" y="1.905" size="1.27" layer="21" font="vector" ratio="10">&gt;NAME</text>
+<text x="-3.175" y="-3.175" size="1.27" layer="21" font="vector">&gt;VALUE</text>
+<rectangle x1="-3.937" y1="-1.905" x2="3.937" y2="1.905" layer="39"/>
+<wire x1="3.2" y1="1.448" x2="3.2" y2="1.6" width="0.127" layer="21"/>
+<wire x1="3.2" y1="-1.6" x2="3.2" y2="-1.448" width="0.127" layer="21"/>
+<wire x1="3.2" y1="-1.473" x2="3.2" y2="1.473" width="0.127" layer="51"/>
+</package>
+<package name="EN_J2">
+<description>Type J2 package for SMD supercap PRT-10317 (p# EEC-EN0F204J2)</description>
+<wire x1="-2.5" y1="-3.5" x2="2.5" y2="-3.5" width="0.127" layer="51"/>
+<wire x1="-2.1" y1="3.5" x2="2.1" y2="3.5" width="0.127" layer="51"/>
+<wire x1="-2.1" y1="3.5" x2="-2.5" y2="3.1" width="0.127" layer="51"/>
+<wire x1="-2.5" y1="3.1" x2="-2.5" y2="2.3" width="0.127" layer="51"/>
+<wire x1="2.1" y1="3.5" x2="2.5" y2="3.1" width="0.127" layer="51"/>
+<wire x1="2.5" y1="3.1" x2="2.5" y2="2.3" width="0.127" layer="51"/>
+<wire x1="-2.5" y1="-3.5" x2="-2.5" y2="-2.3" width="0.127" layer="51"/>
+<wire x1="2.5" y1="-3.5" x2="2.5" y2="-2.3" width="0.127" layer="51"/>
+<wire x1="1.7272" y1="-1.27" x2="1.7272" y2="-2.0828" width="0.127" layer="21"/>
+<wire x1="1.3462" y1="-1.6764" x2="2.159" y2="-1.6764" width="0.127" layer="21"/>
+<circle x="0" y="0" radius="3.4" width="0.127" layer="51"/>
+<smd name="-" x="0" y="2.8" dx="5" dy="2.4" layer="1"/>
+<smd name="+" x="0" y="-3.2" dx="5" dy="1.6" layer="1"/>
+<text x="-3.81" y="-3.81" size="1.27" layer="25" font="vector" ratio="10" rot="R90">&gt;NAME</text>
+<text x="5.08" y="-3.81" size="1.27" layer="27" font="vector" rot="R90">&gt;VALUE</text>
+<rectangle x1="-3.937" y1="-4.191" x2="3.937" y2="4.191" layer="39"/>
+<wire x1="-2.794" y1="-2.159" x2="-2.794" y2="2.159" width="0.127" layer="21" curve="-75.388481"/>
+<wire x1="2.794" y1="2.159" x2="2.794" y2="-2.159" width="0.127" layer="21" curve="-75.388481"/>
+</package>
+<package name="EIA3528-KIT">
+<description>&lt;h3&gt;EIA3528-KIT&lt;/h3&gt;
+&lt;b&gt;Warning:&lt;/b&gt; This is the KIT version of this package. This package has longer pads to make hand soldering easier.&lt;br&gt;</description>
+<wire x1="-0.9" y1="-1.6" x2="-3.1" y2="-1.6" width="0.2032" layer="21"/>
+<wire x1="-3.1" y1="-1.6" x2="-3.1" y2="1.55" width="0.2032" layer="21"/>
+<wire x1="-3.1" y1="1.55" x2="-0.9" y2="1.55" width="0.2032" layer="21"/>
+<wire x1="1" y1="-1.55" x2="2.7" y2="-1.55" width="0.2032" layer="21"/>
+<wire x1="2.7" y1="-1.55" x2="3.1" y2="-1.2" width="0.2032" layer="51"/>
+<wire x1="3.1" y1="-1.2" x2="3.1" y2="1.25" width="0.2032" layer="21"/>
+<wire x1="3.1" y1="1.25" x2="2.7" y2="1.55" width="0.2032" layer="51"/>
+<wire x1="2.7" y1="1.55" x2="1" y2="1.55" width="0.2032" layer="21"/>
+<wire x1="0.609" y1="1.311" x2="0.609" y2="-1.286" width="0.4" layer="21" style="longdash"/>
+<smd name="C" x="-1.9" y="0" dx="1.7" dy="2.5" layer="1"/>
+<smd name="A" x="1.9" y="0" dx="1.7" dy="2.5" layer="1"/>
+<text x="-3.175" y="1.905" size="1.27" layer="25" font="vector" ratio="10">&gt;NAME</text>
+<text x="-3.175" y="-3.175" size="1.27" layer="27" font="vector">&gt;VALUE</text>
+<rectangle x1="-3.683" y1="-1.905" x2="3.683" y2="1.905" layer="39"/>
+</package>
+<package name="EIA3216-KIT">
+<description>&lt;h3&gt;EIA3216-KIT&lt;/h3&gt;
+&lt;b&gt;Warning:&lt;/b&gt; This is the KIT version of this package. This package has longer pads to make hand soldering easier.&lt;br&gt;</description>
+<wire x1="-1" y1="-1.2" x2="-3" y2="-1.2" width="0.2032" layer="21"/>
+<wire x1="-3" y1="-1.2" x2="-3" y2="1.2" width="0.2032" layer="21"/>
+<wire x1="-3" y1="1.2" x2="-1" y2="1.2" width="0.2032" layer="21"/>
+<wire x1="1" y1="-1.2" x2="2.6" y2="-1.2" width="0.2032" layer="21"/>
+<wire x1="2.6" y1="-1.2" x2="3" y2="-0.8" width="0.2032" layer="21"/>
+<wire x1="3" y1="-0.8" x2="3" y2="0.8" width="0.2032" layer="21"/>
+<wire x1="3" y1="0.8" x2="2.6" y2="1.2" width="0.2032" layer="21"/>
+<wire x1="2.6" y1="1.2" x2="1" y2="1.2" width="0.2032" layer="21"/>
+<wire x1="0.381" y1="1.016" x2="0.381" y2="-1.016" width="0.127" layer="21"/>
+<smd name="C" x="-1.65" y="0" dx="1.9" dy="1.6" layer="1"/>
+<smd name="A" x="1.65" y="0" dx="1.9" dy="1.6" layer="1"/>
+<text x="-3.175" y="1.905" size="1.27" layer="25" font="vector" ratio="10">&gt;NAME</text>
+<text x="-3.175" y="-3.175" size="1.27" layer="27" font="vector">&gt;VALUE</text>
+<rectangle x1="-3.683" y1="-1.524" x2="3.683" y2="1.524" layer="39"/>
+</package>
 </packages>
 <symbols>
 <symbol name="GND">
@@ -2346,15 +2664,17 @@ Source: http://www.murata.com .. GRM43DR72E224KW01.pdf</description>
 <text x="-1.27" y="-3.81" size="1.778" layer="96">&gt;VALUE</text>
 <pin name="GND" x="0" y="2.54" visible="off" length="short" direction="sup" rot="R270"/>
 </symbol>
-<symbol name="CAP">
-<wire x1="0" y1="0" x2="0.508" y2="0" width="0.1524" layer="94"/>
-<wire x1="2.54" y1="0" x2="2.032" y2="0" width="0.1524" layer="94"/>
-<text x="-3.81" y="2.54" size="1.778" layer="95">&gt;NAME</text>
-<text x="-3.81" y="-5.08" size="1.778" layer="96">&gt;VALUE</text>
-<rectangle x1="-0.254" y1="-0.254" x2="3.81" y2="0.254" layer="94" rot="R90"/>
-<rectangle x1="-1.27" y1="-0.254" x2="2.794" y2="0.254" layer="94" rot="R90"/>
-<pin name="1" x="-2.54" y="0" visible="off" length="short" direction="pas" swaplevel="1"/>
-<pin name="2" x="5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1" rot="R180"/>
+<symbol name="CAP_POL">
+<wire x1="0" y1="-2.54" x2="0" y2="2.54" width="0.254" layer="94"/>
+<wire x1="1.016" y1="0" x2="2.54" y2="0" width="0.1524" layer="94"/>
+<wire x1="1" y1="0" x2="1.8542" y2="2.4892" width="0.254" layer="94" curve="-37.878202" cap="flat"/>
+<wire x1="1.8504" y1="-2.4669" x2="1.0161" y2="0" width="0.254" layer="94" curve="-37.376341" cap="flat"/>
+<text x="-2.54" y="3.81" size="1.778" layer="95">&gt;NAME</text>
+<text x="-2.54" y="-5.08" size="1.778" layer="96">&gt;VALUE</text>
+<rectangle x1="-1.176" y1="-1.872" x2="-0.287" y2="-1.745" layer="94" rot="R90"/>
+<rectangle x1="-0.795" y1="-2.253" x2="-0.668" y2="-1.364" layer="94" rot="R90"/>
+<pin name="+" x="-2.54" y="0" visible="off" length="short" direction="pas" swaplevel="1"/>
+<pin name="-" x="5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1" rot="R180"/>
 </symbol>
 <symbol name="5V">
 <wire x1="0.762" y1="1.27" x2="0" y2="2.54" width="0.254" layer="94"/>
@@ -2484,17 +2804,44 @@ Source: http://www.murata.com .. GRM43DR72E224KW01.pdf</description>
 </device>
 </devices>
 </deviceset>
-<deviceset name="CAP" prefix="C" uservalue="yes">
-<description>&lt;b&gt;Capacitor&lt;/b&gt;
-Standard 0603 ceramic capacitor, and 0.1" leaded capacitor.</description>
+<deviceset name="CAP_POL" prefix="C" uservalue="yes">
+<description>&lt;b&gt;Capacitor Polarized&lt;/b&gt;
+These are standard SMD and PTH capacitors. Normally 10uF, 47uF, and 100uF in electrolytic and tantalum varieties. Always verify the external diameter of the through hole cap, it varies with capacity, voltage, and manufacturer. The EIA devices should be standard.</description>
 <gates>
-<gate name="G$1" symbol="CAP" x="0" y="0"/>
+<gate name="G$1" symbol="CAP_POL" x="0" y="0"/>
 </gates>
 <devices>
-<device name="0805" package="0805">
+<device name="1206" package="EIA3216">
 <connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="+" pad="A"/>
+<connect gate="G$1" pin="-" pad="C"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="3528" package="EIA3528">
+<connects>
+<connect gate="G$1" pin="+" pad="A"/>
+<connect gate="G$1" pin="-" pad="C"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="7343" package="EIA7343">
+<connects>
+<connect gate="G$1" pin="+" pad="A"/>
+<connect gate="G$1" pin="-" pad="C"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="G" package="PANASONIC_G">
+<connects>
+<connect gate="G$1" pin="+" pad="+"/>
+<connect gate="G$1" pin="-" pad="-"/>
 </connects>
 <technologies>
 <technology name="">
@@ -2502,70 +2849,94 @@ Standard 0603 ceramic capacitor, and 0.1" leaded capacitor.</description>
 </technology>
 </technologies>
 </device>
-<device name="SMD" package="GRM43D">
+<device name="E" package="PANASONIC_E">
 <connects>
-<connect gate="G$1" pin="1" pad="A"/>
-<connect gate="G$1" pin="2" pad="C"/>
+<connect gate="G$1" pin="+" pad="+"/>
+<connect gate="G$1" pin="-" pad="-"/>
 </connects>
 <technologies>
-<technology name="">
-<attribute name="PIE-INT-REF-NUM" value="CAPACITOR-GENERIC"/>
-</technology>
+<technology name=""/>
 </technologies>
 </device>
-<device name="0603-CAP" package="0603-CAP">
+<device name="C" package="PANASONIC_C">
 <connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="+" pad="+"/>
+<connect gate="G$1" pin="-" pad="-"/>
 </connects>
 <technologies>
-<technology name="">
-<attribute name="PIE-INT-REF-NUM" value="CAPACITOR-GENERIC"/>
-</technology>
+<technology name=""/>
 </technologies>
 </device>
-<device name="0402-CAP" package="0402-CAP">
+<device name="F80" package="NIPPON_F80">
 <connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="+" pad="+"/>
+<connect gate="G$1" pin="-" pad="-"/>
 </connects>
 <technologies>
-<technology name="">
-<attribute name="PIE-INT-REF-NUM" value="CAPACITOR-GENERIC"/>
-</technology>
+<technology name=""/>
 </technologies>
 </device>
-<device name="1210" package="1210">
+<device name="D" package="PANASONIC_D">
 <connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="+" pad="+"/>
+<connect gate="G$1" pin="-" pad="-"/>
 </connects>
 <technologies>
-<technology name="">
-<attribute name="PIE-INT-REF-NUM" value="CAPACITOR-GENERIC"/>
-</technology>
+<technology name=""/>
 </technologies>
 </device>
-<device name="1206" package="1206">
+<device name="SMD" package="VISHAY_C">
 <connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="+" pad="+"/>
+<connect gate="G$1" pin="-" pad="-"/>
 </connects>
 <technologies>
-<technology name="">
-<attribute name="PIE-INT-REF-NUM" value="CAPACITOR-GENERIC"/>
-</technology>
+<technology name=""/>
 </technologies>
 </device>
-<device name="ASMD" package="CTZ3">
+<device name="H13" package="PANASONIC_H13">
 <connects>
-<connect gate="G$1" pin="1" pad="+"/>
-<connect gate="G$1" pin="2" pad="-"/>
+<connect gate="G$1" pin="+" pad="+"/>
+<connect gate="G$1" pin="-" pad="-"/>
 </connects>
 <technologies>
-<technology name="">
-<attribute name="PIE-INT-REF-NUM" value="CAPACITOR-GENERIC"/>
-</technology>
+<technology name=""/>
+</technologies>
+</device>
+<device name="6032" package="EIA6032">
+<connects>
+<connect gate="G$1" pin="+" pad="P$1"/>
+<connect gate="G$1" pin="-" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="EN_J2" package="EN_J2">
+<connects>
+<connect gate="G$1" pin="+" pad="+"/>
+<connect gate="G$1" pin="-" pad="-"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="3528-KIT" package="EIA3528-KIT">
+<connects>
+<connect gate="G$1" pin="+" pad="A"/>
+<connect gate="G$1" pin="-" pad="C"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="1206-KIT" package="EIA3216-KIT">
+<connects>
+<connect gate="G$1" pin="+" pad="A"/>
+<connect gate="G$1" pin="-" pad="C"/>
+</connects>
+<technologies>
+<technology name=""/>
 </technologies>
 </device>
 </devices>
@@ -4113,10 +4484,10 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <part name="BATT" library="pie" deviceset="ANDERSON" device="HORIZONTAL" value="12V"/>
 <part name="FRAME1" library="pie" deviceset="FRAME-LETTER" device="">
 <attribute name="AUTHOR" value="Casey Duckering"/>
-<attribute name="REVISION" value="1A"/>
+<attribute name="REVISION" value="1B"/>
 </part>
-<part name="C1" library="pie" deviceset="CAP" device="1206" value="2.2 uF TANT"/>
-<part name="C2" library="pie" deviceset="CAP" device="1206" value="2.2 uF TANT"/>
+<part name="C1" library="pie" deviceset="CAP_POL" device="1206" value="2.2 uF TANT"/>
+<part name="C2" library="pie" deviceset="CAP_POL" device="1206" value="2.2 uF TANT"/>
 <part name="VREG" library="pie" deviceset="V_REG_LT323A" device=""/>
 <part name="SUPPLY1" library="pie" deviceset="GND" device=""/>
 <part name="U$1" library="pie" deviceset="5V" device=""/>
@@ -4211,7 +4582,7 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <nets>
 <net name="GND" class="0">
 <segment>
-<pinref part="C1" gate="G$1" pin="1"/>
+<pinref part="C1" gate="G$1" pin="+"/>
 <wire x1="45.72" y1="152.4" x2="45.72" y2="157.48" width="0.1524" layer="91"/>
 <pinref part="BATT" gate="G$1" pin="GND"/>
 <wire x1="35.56" y1="165.1" x2="38.1" y2="165.1" width="0.1524" layer="91"/>
@@ -4223,7 +4594,7 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <wire x1="58.42" y1="152.4" x2="58.42" y2="162.56" width="0.1524" layer="91"/>
 <wire x1="45.72" y1="152.4" x2="58.42" y2="152.4" width="0.1524" layer="91"/>
 <junction x="58.42" y="152.4"/>
-<pinref part="C2" gate="G$1" pin="1"/>
+<pinref part="C2" gate="G$1" pin="+"/>
 <wire x1="76.2" y1="152.4" x2="76.2" y2="157.48" width="0.1524" layer="91"/>
 <wire x1="58.42" y1="152.4" x2="63.5" y2="152.4" width="0.1524" layer="91"/>
 <pinref part="VREG" gate="G$1" pin="BDY"/>
@@ -4269,7 +4640,7 @@ You are welcome to use this library for commercial purposes. For attribution, we
 </net>
 <net name="5V" class="0">
 <segment>
-<pinref part="C2" gate="G$1" pin="2"/>
+<pinref part="C2" gate="G$1" pin="-"/>
 <pinref part="U$1" gate="G$1" pin="5V"/>
 <wire x1="76.2" y1="175.26" x2="76.2" y2="170.18" width="0.1524" layer="91"/>
 <pinref part="VREG" gate="G$1" pin="OUT"/>
@@ -4303,7 +4674,7 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <pinref part="BATT" gate="G$1" pin="VCC"/>
 <pinref part="VREG" gate="G$1" pin="IN"/>
 <wire x1="35.56" y1="170.18" x2="45.72" y2="170.18" width="0.1524" layer="91"/>
-<pinref part="C1" gate="G$1" pin="2"/>
+<pinref part="C1" gate="G$1" pin="-"/>
 <wire x1="45.72" y1="170.18" x2="53.34" y2="170.18" width="0.1524" layer="91"/>
 <wire x1="45.72" y1="165.1" x2="45.72" y2="170.18" width="0.1524" layer="91"/>
 <junction x="45.72" y="170.18"/>

--- a/eda/cape.sch
+++ b/eda/cape.sch
@@ -4484,7 +4484,7 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <part name="BATT" library="pie" deviceset="ANDERSON" device="HORIZONTAL" value="12V"/>
 <part name="FRAME1" library="pie" deviceset="FRAME-LETTER" device="">
 <attribute name="AUTHOR" value="Casey Duckering"/>
-<attribute name="REVISION" value="1C"/>
+<attribute name="REVISION" value="1B"/>
 </part>
 <part name="C1" library="pie" deviceset="CAP_POL" device="1206" value="2.2 uF TANT"/>
 <part name="C2" library="pie" deviceset="CAP_POL" device="1206" value="2.2 uF TANT"/>
@@ -4522,13 +4522,13 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <attribute name="SHEET" x="233.68" y="1.27" size="2.54" layer="94" font="vector" ratio="15"/>
 <attribute name="DRAWING_NAME" x="162.814" y="17.78" size="2.7432" layer="94" font="vector" ratio="15"/>
 </instance>
-<instance part="C1" gate="G$1" x="45.72" y="160.02" smashed="yes" rot="R90">
-<attribute name="NAME" x="43.18" y="163.83" size="1.778" layer="95" rot="R180"/>
-<attribute name="VALUE" x="52.07" y="157.226" size="1.778" layer="96" rot="R180"/>
+<instance part="C1" gate="G$1" x="43.18" y="162.56" smashed="yes" rot="R270">
+<attribute name="NAME" x="38.862" y="164.592" size="1.778" layer="95"/>
+<attribute name="VALUE" x="44.45" y="158.75" size="1.778" layer="96"/>
 </instance>
-<instance part="C2" gate="G$1" x="76.2" y="160.02" smashed="yes" rot="R90">
-<attribute name="NAME" x="73.66" y="163.83" size="1.778" layer="95" rot="R180"/>
-<attribute name="VALUE" x="83.312" y="157.988" size="1.778" layer="96" rot="R180"/>
+<instance part="C2" gate="G$1" x="76.2" y="162.56" smashed="yes" rot="R270">
+<attribute name="NAME" x="71.12" y="163.83" size="1.778" layer="95"/>
+<attribute name="VALUE" x="90.678" y="159.766" size="1.778" layer="96" rot="R180"/>
 </instance>
 <instance part="VREG" gate="G$1" x="60.96" y="168.91" smashed="yes">
 <attribute name="NAME" x="55.88" y="176.53" size="1.778" layer="95"/>
@@ -4582,25 +4582,25 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <nets>
 <net name="GND" class="0">
 <segment>
-<pinref part="C1" gate="G$1" pin="+"/>
-<wire x1="45.72" y1="152.4" x2="45.72" y2="157.48" width="0.1524" layer="91"/>
 <pinref part="BATT" gate="G$1" pin="GND"/>
 <wire x1="35.56" y1="165.1" x2="38.1" y2="165.1" width="0.1524" layer="91"/>
 <wire x1="38.1" y1="165.1" x2="38.1" y2="152.4" width="0.1524" layer="91"/>
-<wire x1="38.1" y1="152.4" x2="45.72" y2="152.4" width="0.1524" layer="91"/>
-<junction x="45.72" y="152.4"/>
 <pinref part="SUPPLY1" gate="GND" pin="GND"/>
 <pinref part="VREG" gate="G$1" pin="GND"/>
 <wire x1="58.42" y1="152.4" x2="58.42" y2="162.56" width="0.1524" layer="91"/>
-<wire x1="45.72" y1="152.4" x2="58.42" y2="152.4" width="0.1524" layer="91"/>
+<wire x1="38.1" y1="152.4" x2="43.18" y2="152.4" width="0.1524" layer="91"/>
 <junction x="58.42" y="152.4"/>
-<pinref part="C2" gate="G$1" pin="+"/>
-<wire x1="76.2" y1="152.4" x2="76.2" y2="157.48" width="0.1524" layer="91"/>
+<wire x1="43.18" y1="152.4" x2="58.42" y2="152.4" width="0.1524" layer="91"/>
 <wire x1="58.42" y1="152.4" x2="63.5" y2="152.4" width="0.1524" layer="91"/>
 <pinref part="VREG" gate="G$1" pin="BDY"/>
 <wire x1="63.5" y1="152.4" x2="76.2" y2="152.4" width="0.1524" layer="91"/>
 <wire x1="63.5" y1="162.56" x2="63.5" y2="152.4" width="0.1524" layer="91"/>
 <junction x="63.5" y="152.4"/>
+<pinref part="C1" gate="G$1" pin="-"/>
+<wire x1="43.18" y1="157.48" x2="43.18" y2="152.4" width="0.1524" layer="91"/>
+<junction x="43.18" y="152.4"/>
+<pinref part="C2" gate="G$1" pin="-"/>
+<wire x1="76.2" y1="157.48" x2="76.2" y2="152.4" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="SUPPLY2" gate="GND" pin="GND"/>
@@ -4640,12 +4640,12 @@ You are welcome to use this library for commercial purposes. For attribution, we
 </net>
 <net name="5V" class="0">
 <segment>
-<pinref part="C2" gate="G$1" pin="-"/>
 <pinref part="U$1" gate="G$1" pin="5V"/>
 <wire x1="76.2" y1="175.26" x2="76.2" y2="170.18" width="0.1524" layer="91"/>
 <pinref part="VREG" gate="G$1" pin="OUT"/>
-<wire x1="76.2" y1="170.18" x2="76.2" y2="165.1" width="0.1524" layer="91"/>
 <wire x1="68.58" y1="170.18" x2="76.2" y2="170.18" width="0.1524" layer="91"/>
+<pinref part="C2" gate="G$1" pin="+"/>
+<wire x1="76.2" y1="170.18" x2="76.2" y2="165.1" width="0.1524" layer="91"/>
 <junction x="76.2" y="170.18"/>
 </segment>
 <segment>
@@ -4673,12 +4673,12 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <segment>
 <pinref part="BATT" gate="G$1" pin="VCC"/>
 <pinref part="VREG" gate="G$1" pin="IN"/>
-<wire x1="35.56" y1="170.18" x2="45.72" y2="170.18" width="0.1524" layer="91"/>
-<pinref part="C1" gate="G$1" pin="-"/>
-<wire x1="45.72" y1="170.18" x2="53.34" y2="170.18" width="0.1524" layer="91"/>
-<wire x1="45.72" y1="165.1" x2="45.72" y2="170.18" width="0.1524" layer="91"/>
-<junction x="45.72" y="170.18"/>
+<wire x1="35.56" y1="170.18" x2="43.18" y2="170.18" width="0.1524" layer="91"/>
 <label x="38.1" y="170.18" size="1.778" layer="95" font="vector" ratio="15"/>
+<pinref part="C1" gate="G$1" pin="+"/>
+<wire x1="43.18" y1="170.18" x2="53.34" y2="170.18" width="0.1524" layer="91"/>
+<wire x1="43.18" y1="165.1" x2="43.18" y2="170.18" width="0.1524" layer="91"/>
+<junction x="43.18" y="170.18"/>
 </segment>
 <segment>
 <pinref part="J2" gate="G$1" pin="VCC"/>

--- a/eda/cape.sch
+++ b/eda/cape.sch
@@ -4484,11 +4484,11 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <part name="BATT" library="pie" deviceset="ANDERSON" device="HORIZONTAL" value="12V"/>
 <part name="FRAME1" library="pie" deviceset="FRAME-LETTER" device="">
 <attribute name="AUTHOR" value="Casey Duckering"/>
-<attribute name="REVISION" value="1B"/>
+<attribute name="REVISION" value="1C"/>
 </part>
 <part name="C1" library="pie" deviceset="CAP_POL" device="1206" value="2.2 uF TANT"/>
 <part name="C2" library="pie" deviceset="CAP_POL" device="1206" value="2.2 uF TANT"/>
-<part name="VREG" library="pie" deviceset="V_REG_LT323A" device=""/>
+<part name="VREG" library="pie" deviceset="V_REG_LT323A" device="" value="LT323A"/>
 <part name="SUPPLY1" library="pie" deviceset="GND" device=""/>
 <part name="U$1" library="pie" deviceset="5V" device=""/>
 <part name="CAPE" library="SparkFun-Boards" deviceset="BEAGLE_BONE_BLACK_CAPE" device=""/>
@@ -4523,12 +4523,12 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <attribute name="DRAWING_NAME" x="162.814" y="17.78" size="2.7432" layer="94" font="vector" ratio="15"/>
 </instance>
 <instance part="C1" gate="G$1" x="45.72" y="160.02" smashed="yes" rot="R90">
-<attribute name="NAME" x="43.18" y="156.21" size="1.778" layer="95" rot="R90"/>
-<attribute name="VALUE" x="50.8" y="156.21" size="1.778" layer="96" rot="R90"/>
+<attribute name="NAME" x="43.18" y="163.83" size="1.778" layer="95" rot="R180"/>
+<attribute name="VALUE" x="52.07" y="157.226" size="1.778" layer="96" rot="R180"/>
 </instance>
 <instance part="C2" gate="G$1" x="76.2" y="160.02" smashed="yes" rot="R90">
-<attribute name="NAME" x="73.66" y="156.21" size="1.778" layer="95" rot="R90"/>
-<attribute name="VALUE" x="81.28" y="156.21" size="1.778" layer="96" rot="R90"/>
+<attribute name="NAME" x="73.66" y="163.83" size="1.778" layer="95" rot="R180"/>
+<attribute name="VALUE" x="83.312" y="157.988" size="1.778" layer="96" rot="R180"/>
 </instance>
 <instance part="VREG" gate="G$1" x="60.96" y="168.91" smashed="yes">
 <attribute name="NAME" x="55.88" y="176.53" size="1.778" layer="95"/>
@@ -4542,23 +4542,23 @@ You are welcome to use this library for commercial purposes. For attribution, we
 </instance>
 <instance part="CAPE" gate="P8" x="86.36" y="101.6" smashed="yes"/>
 <instance part="CAPE" gate="P9" x="170.18" y="101.6" smashed="yes"/>
-<instance part="U$4" gate="G$1" x="142.24" y="124.46" smashed="yes" rot="R90">
-<attribute name="VALUE" x="138.43" y="123.19" size="1.778" layer="96" rot="R90"/>
+<instance part="U$4" gate="G$1" x="139.7" y="121.92" smashed="yes">
+<attribute name="VALUE" x="143.51" y="124.714" size="1.778" layer="96" rot="R180"/>
 </instance>
-<instance part="U$5" gate="G$1" x="198.12" y="124.46" smashed="yes" rot="R270">
-<attribute name="VALUE" x="201.93" y="125.73" size="1.778" layer="96" rot="R270"/>
+<instance part="U$5" gate="G$1" x="198.12" y="121.92" smashed="yes">
+<attribute name="VALUE" x="197.358" y="125.222" size="1.778" layer="96" rot="R180"/>
 </instance>
-<instance part="SUPPLY2" gate="GND" x="139.7" y="127" smashed="yes" rot="R270">
-<attribute name="VALUE" x="135.89" y="128.27" size="1.778" layer="96" rot="R270"/>
+<instance part="SUPPLY2" gate="GND" x="130.556" y="124.46" smashed="yes">
+<attribute name="VALUE" x="132.842" y="122.428" size="1.778" layer="96" rot="R180"/>
 </instance>
-<instance part="SUPPLY3" gate="GND" x="200.66" y="127" smashed="yes" rot="R90">
-<attribute name="VALUE" x="204.47" y="125.73" size="1.778" layer="96" rot="R90"/>
+<instance part="SUPPLY3" gate="GND" x="208.28" y="124.46" smashed="yes">
+<attribute name="VALUE" x="209.296" y="121.666" size="1.778" layer="96" rot="R180"/>
 </instance>
 <instance part="J2" gate="G$1" x="27.94" y="35.56" smashed="yes"/>
 <instance part="J3" gate="G$1" x="78.74" y="35.56" smashed="yes"/>
 <instance part="R1" gate="G$1" x="134.62" y="170.18" smashed="yes" rot="R90">
-<attribute name="NAME" x="132.08" y="165.1" size="1.778" layer="95" rot="R90"/>
-<attribute name="VALUE" x="138.43" y="165.1" size="1.778" layer="96" rot="R90"/>
+<attribute name="NAME" x="132.08" y="170.18" size="1.778" layer="95" rot="R180"/>
+<attribute name="VALUE" x="140.97" y="170.18" size="1.778" layer="96" rot="R180"/>
 </instance>
 <instance part="ON" gate="G$1" x="134.62" y="158.75" smashed="yes" rot="R270">
 <attribute name="NAME" x="138.43" y="154.94" size="1.778" layer="95" font="vector" ratio="15" rot="R90"/>
@@ -4570,11 +4570,11 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <instance part="U$7" gate="G$1" x="134.62" y="177.8" smashed="yes">
 <attribute name="VALUE" x="133.35" y="181.61" size="1.778" layer="96"/>
 </instance>
-<instance part="SUPPLY4" gate="GND" x="55.88" y="127" smashed="yes" rot="R270">
-<attribute name="VALUE" x="52.07" y="128.27" size="1.778" layer="96" rot="R270"/>
+<instance part="SUPPLY4" gate="GND" x="53.34" y="124.46" smashed="yes">
+<attribute name="VALUE" x="52.07" y="120.65" size="1.778" layer="96"/>
 </instance>
-<instance part="SUPPLY5" gate="GND" x="116.84" y="127" smashed="yes" rot="R90">
-<attribute name="VALUE" x="120.65" y="125.73" size="1.778" layer="96" rot="R90"/>
+<instance part="SUPPLY5" gate="GND" x="116.84" y="124.46" smashed="yes">
+<attribute name="VALUE" x="115.57" y="120.65" size="1.778" layer="96"/>
 </instance>
 </instances>
 <busses>
@@ -4605,12 +4605,12 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <segment>
 <pinref part="SUPPLY2" gate="GND" pin="GND"/>
 <pinref part="CAPE" gate="P9" pin="DGND@1"/>
-<wire x1="142.24" y1="127" x2="149.86" y2="127" width="0.1524" layer="91"/>
+<wire x1="130.556" y1="127" x2="149.86" y2="127" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="CAPE" gate="P9" pin="DGND@2"/>
 <pinref part="SUPPLY3" gate="GND" pin="GND"/>
-<wire x1="190.5" y1="127" x2="198.12" y2="127" width="0.1524" layer="91"/>
+<wire x1="190.5" y1="127" x2="208.28" y2="127" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="J2" gate="G$1" pin="GND"/>
@@ -4630,12 +4630,12 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <segment>
 <pinref part="SUPPLY4" gate="GND" pin="GND"/>
 <pinref part="CAPE" gate="P8" pin="DGND@1"/>
-<wire x1="58.42" y1="127" x2="66.04" y2="127" width="0.1524" layer="91"/>
+<wire x1="53.34" y1="127" x2="66.04" y2="127" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="CAPE" gate="P8" pin="DGND@2"/>
 <pinref part="SUPPLY5" gate="GND" pin="GND"/>
-<wire x1="106.68" y1="127" x2="114.3" y2="127" width="0.1524" layer="91"/>
+<wire x1="106.68" y1="127" x2="116.84" y2="127" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="5V" class="0">
@@ -4649,16 +4649,6 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <junction x="76.2" y="170.18"/>
 </segment>
 <segment>
-<pinref part="U$4" gate="G$1" pin="5V"/>
-<pinref part="CAPE" gate="P9" pin="VDD_3V3@1"/>
-<wire x1="142.24" y1="124.46" x2="149.86" y2="124.46" width="0.1524" layer="91"/>
-</segment>
-<segment>
-<pinref part="CAPE" gate="P9" pin="VDD_3V3@2"/>
-<pinref part="U$5" gate="G$1" pin="5V"/>
-<wire x1="190.5" y1="124.46" x2="198.12" y2="124.46" width="0.1524" layer="91"/>
-</segment>
-<segment>
 <pinref part="J3" gate="G$1" pin="VCC"/>
 <wire x1="86.36" y1="38.1" x2="96.52" y2="38.1" width="0.1524" layer="91"/>
 <label x="88.9" y="38.1" size="1.778" layer="95" font="vector" ratio="15"/>
@@ -4667,6 +4657,16 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <wire x1="134.62" y1="177.8" x2="134.62" y2="175.26" width="0.1524" layer="91"/>
 <pinref part="R1" gate="G$1" pin="2"/>
 <pinref part="U$7" gate="G$1" pin="5V"/>
+</segment>
+<segment>
+<pinref part="U$4" gate="G$1" pin="5V"/>
+<pinref part="CAPE" gate="P9" pin="VDD_5V@1"/>
+<wire x1="139.7" y1="121.92" x2="149.86" y2="121.92" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="CAPE" gate="P9" pin="VDD_5V@2"/>
+<pinref part="U$5" gate="G$1" pin="5V"/>
+<wire x1="190.5" y1="121.92" x2="198.12" y2="121.92" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="12V" class="0">
@@ -4696,6 +4696,13 @@ You are welcome to use this library for commercial purposes. For attribution, we
 </nets>
 </sheet>
 </sheets>
+<errors>
+<approved hash="208,1,76.2,175.26,5V,sup,,,,"/>
+<approved hash="208,1,68.58,170.18,5V,out,,,,"/>
+<approved hash="208,1,134.62,177.8,5V,sup,,,,"/>
+<approved hash="208,1,139.7,121.92,5V,sup,,,,"/>
+<approved hash="208,1,198.12,121.92,5V,sup,,,,"/>
+</errors>
 </schematic>
 </drawing>
 </eagle>


### PR DESCRIPTION
- Change name from "Top Board" to "Woodstock"
- Switched the 12V and GND label to make it correct
- Change size of drill hole from 1.25 to 0.75
- Change 2.2uF capacitor to 2.2uF a polarised Tantalum Capacitor