### PR TITLE
Fix for smartsensorPowered brd and sch

### DIFF
--- a/eda/smartsensorPowered.brd
+++ b/eda/smartsensorPowered.brd
@@ -1357,14 +1357,8 @@ design rules under a new name.</description>
 <via x="36.576" y="19.431" extent="1-16" drill="0.508"/>
 <wire x1="36.576" y1="19.431" x2="34.036" y2="16.891" width="0.508" layer="16"/>
 <via x="34.036" y="16.891" extent="1-16" drill="0.508"/>
-<wire x1="33.528" y1="17.145" x2="33.147" y2="16.764" width="0.508" layer="1"/>
-<wire x1="33.147" y1="16.764" x2="33.147" y2="15.875" width="0.508" layer="1"/>
-<wire x1="33.147" y1="15.875" x2="33.144" y2="15.878" width="0.508" layer="1"/>
-<wire x1="33.144" y1="15.878" x2="31.75" y2="15.878" width="0.508" layer="1"/>
-<wire x1="34.036" y1="16.891" x2="33.782" y2="17.145" width="0.508" layer="1"/>
-<wire x1="33.782" y1="17.145" x2="33.528" y2="17.145" width="0.508" layer="1"/>
 </signal>
-<signal name="N$1">
+<signal name="6V_IF_SERVO1">
 <contactref element="JP1" pad="1"/>
 <contactref element="Q1" pad="3"/>
 <contactref element="SJ1" pad="2"/>
@@ -1407,7 +1401,7 @@ design rules under a new name.</description>
 <wire x1="10.861" y1="2.302" x2="9.636" y2="2.302" width="0.2032" layer="1"/>
 <wire x1="9.636" y1="2.302" x2="5.461" y2="6.477" width="0.2032" layer="1"/>
 </signal>
-<signal name="N$4">
+<signal name="6V_IF_SERVO2">
 <contactref element="JP2" pad="1"/>
 <contactref element="Q2" pad="3"/>
 <contactref element="SJ2" pad="2"/>
@@ -1446,7 +1440,7 @@ design rules under a new name.</description>
 <wire x1="13.97" y1="2.286" x2="15.036" y2="2.286" width="0.2032" layer="1"/>
 <wire x1="15.036" y1="2.286" x2="15.052" y2="2.302" width="0.2032" layer="1"/>
 </signal>
-<signal name="N$7">
+<signal name="6V_IF_SERVO3">
 <contactref element="JP3" pad="1"/>
 <contactref element="Q3" pad="3"/>
 <contactref element="SJ3" pad="2"/>
@@ -1498,7 +1492,7 @@ design rules under a new name.</description>
 <wire x1="19.37" y1="2.225" x2="18.415" y2="1.27" width="0.2032" layer="1"/>
 <wire x1="18.415" y1="1.27" x2="8.255" y2="1.27" width="0.2032" layer="1"/>
 </signal>
-<signal name="N$10">
+<signal name="6V_IF_SERVO4">
 <contactref element="JP4" pad="1"/>
 <contactref element="Q4" pad="3"/>
 <contactref element="SJ4" pad="2"/>

--- a/eda/smartsensorPowered.brd
+++ b/eda/smartsensorPowered.brd
@@ -129,15 +129,15 @@
 <wire x1="59.69" y1="0" x2="59.69" y2="27.94" width="0.254" layer="20"/>
 <wire x1="59.69" y1="27.94" x2="0" y2="27.94" width="0.254" layer="20"/>
 <wire x1="0" y1="27.94" x2="0" y2="0" width="0.254" layer="20"/>
-<text x="52.8574" y="0.762" size="0.889" layer="16" font="vector" ratio="20" rot="MR0">v4 rev B
-28 Oct 2015</text>
+<text x="52.8574" y="0.762" size="0.889" layer="16" font="vector" ratio="20" rot="MR0">v4 rev C
+31 Oct 2015</text>
 <text x="44.196" y="26.162" size="0.762" layer="22" font="vector" ratio="20" rot="MR270">(c) Pioneers in Engineering.
 Design by: Vincent D, Devin H, Kate R,
 Andrew H, Sumita G, Tobin H, Casey D.
 This design is open source hardware.
 For more information, visit 
 pioneers.berkeley.edu/opensource.</text>
-<text x="1.1684" y="26.9748" size="0.762" layer="21" font="vector" ratio="15">Powered Smartsensor Board Version 4 Rev. B</text>
+<text x="1.1684" y="26.9748" size="0.762" layer="21" font="vector" ratio="15">Powered Smartsensor Board Version 4 Rev. C</text>
 <rectangle x1="49.911" y1="22.606" x2="51.181" y2="23.876" layer="22" rot="R90"/>
 <text x="51.181" y="22.225" size="1.27" layer="22" font="vector" ratio="15" rot="MR270">SERVO</text>
 <rectangle x1="49.911" y1="14.986" x2="51.181" y2="16.256" layer="22" rot="R90"/>

--- a/eda/smartsensorPowered.brd
+++ b/eda/smartsensorPowered.brd
@@ -129,8 +129,8 @@
 <wire x1="59.69" y1="0" x2="59.69" y2="27.94" width="0.254" layer="20"/>
 <wire x1="59.69" y1="27.94" x2="0" y2="27.94" width="0.254" layer="20"/>
 <wire x1="0" y1="27.94" x2="0" y2="0" width="0.254" layer="20"/>
-<text x="52.8574" y="0.762" size="0.889" layer="16" font="vector" ratio="20" rot="MR0">v4 rev C
-31 Oct 2015</text>
+<text x="52.8574" y="0.762" size="0.889" layer="16" font="vector" ratio="20" rot="MR0">v4 rev B
+5 Nov 2015</text>
 <text x="44.196" y="26.162" size="0.762" layer="22" font="vector" ratio="20" rot="MR270">(c) Pioneers in Engineering.
 Design by: Vincent D, Devin H, Kate R,
 Andrew H, Sumita G, Tobin H, Casey D.

--- a/eda/smartsensorPowered.brd
+++ b/eda/smartsensorPowered.brd
@@ -137,7 +137,7 @@ Andrew H, Sumita G, Tobin H, Casey D.
 This design is open source hardware.
 For more information, visit 
 pioneers.berkeley.edu/opensource.</text>
-<text x="1.1684" y="26.9748" size="0.762" layer="21" font="vector" ratio="15">Powered Smartsensor Board Version 4 Rev. C</text>
+<text x="1.1684" y="26.9748" size="0.762" layer="21" font="vector" ratio="15">Powered Smartsensor Board Version 4 Rev. B</text>
 <rectangle x1="49.911" y1="22.606" x2="51.181" y2="23.876" layer="22" rot="R90"/>
 <text x="51.181" y="22.225" size="1.27" layer="22" font="vector" ratio="15" rot="MR270">SERVO</text>
 <rectangle x1="49.911" y1="14.986" x2="51.181" y2="16.256" layer="22" rot="R90"/>

--- a/eda/smartsensorPowered.brd
+++ b/eda/smartsensorPowered.brd
@@ -129,15 +129,15 @@
 <wire x1="59.69" y1="0" x2="59.69" y2="27.94" width="0.254" layer="20"/>
 <wire x1="59.69" y1="27.94" x2="0" y2="27.94" width="0.254" layer="20"/>
 <wire x1="0" y1="27.94" x2="0" y2="0" width="0.254" layer="20"/>
-<text x="52.8574" y="0.762" size="0.889" layer="16" font="vector" ratio="20" rot="MR0">v4 rev A
-9 Oct 2015</text>
+<text x="52.8574" y="0.762" size="0.889" layer="16" font="vector" ratio="20" rot="MR0">v4 rev B
+28 Oct 2015</text>
 <text x="44.196" y="26.162" size="0.762" layer="22" font="vector" ratio="20" rot="MR270">(c) Pioneers in Engineering.
 Design by: Vincent D, Devin H, Kate R,
 Andrew H, Sumita G, Tobin H, Casey D.
 This design is open source hardware.
 For more information, visit 
 pioneers.berkeley.edu/opensource.</text>
-<text x="1.1684" y="26.9748" size="0.762" layer="21" font="vector" ratio="15">Powered Smartsensor Board Version 4 Rev. A</text>
+<text x="1.1684" y="26.9748" size="0.762" layer="21" font="vector" ratio="15">Powered Smartsensor Board Version 4 Rev. B</text>
 <rectangle x1="49.911" y1="22.606" x2="51.181" y2="23.876" layer="22" rot="R90"/>
 <text x="51.181" y="22.225" size="1.27" layer="22" font="vector" ratio="15" rot="MR270">SERVO</text>
 <rectangle x1="49.911" y1="14.986" x2="51.181" y2="16.256" layer="22" rot="R90"/>
@@ -153,6 +153,8 @@ pioneers.berkeley.edu/opensource.</text>
 <text x="32.385" y="8.636" size="1.016" layer="21" font="vector" ratio="15">6V</text>
 <text x="31.369" y="4.826" size="1.016" layer="21" font="vector" ratio="15">12V</text>
 <wire x1="53.34" y1="21.971" x2="51.562" y2="21.971" width="0.2032" layer="22"/>
+<circle x="19.304" y="16.002" radius="0" width="0.4064" layer="21"/>
+<circle x="11.43" y="16.002" radius="0" width="0.4064" layer="21"/>
 </plain>
 <libraries>
 <library name="pie">
@@ -1132,10 +1134,10 @@ design rules under a new name.</description>
 <attribute name="VALUE" x="23.495" y="5.969" size="0.6096" layer="27" font="vector" ratio="15" rot="R180"/>
 <attribute name="PIE-INT-REF-NUM" value="DIODE" x="22.225" y="7.62" size="1.778" layer="27" rot="R180" display="off"/>
 </element>
-<element name="JP1" library="pie" package="1X03-MTA" value="" x="14.1478" y="19.685" smashed="yes" rot="R180">
-<attribute name="PIE-INT-REF-NUM" value="MTA" x="14.1478" y="19.685" size="1.778" layer="27" rot="R180" display="off"/>
-<attribute name="NAME" x="17.93875" y="22.01545" size="0.762" layer="25" font="vector" ratio="15" rot="R180"/>
-<attribute name="VALUE" x="17.9578" y="24.13" size="1.27" layer="27" font="vector" rot="R180"/>
+<element name="JP1" library="pie" package="1X03-MTA" value="" x="13.8938" y="19.685" smashed="yes" rot="R180">
+<attribute name="PIE-INT-REF-NUM" value="MTA" x="13.8938" y="19.685" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="NAME" x="9.17575" y="20.49145" size="0.635" layer="25" font="vector" ratio="15" rot="R270"/>
+<attribute name="VALUE" x="17.7038" y="24.13" size="1.27" layer="27" font="vector" rot="R180"/>
 </element>
 <element name="SJ1" library="pie" package="SJ_2S-NO" value="SOLDERJUMPERNO" x="2.1082" y="11.176" smashed="yes">
 <attribute name="PIE-INT-REF-NUM" value="DNL" x="2.1082" y="11.176" size="1.778" layer="27" display="off"/>
@@ -1154,10 +1156,10 @@ design rules under a new name.</description>
 <attribute name="VALUE" x="14.986" y="26.416" size="0.6096" layer="27" font="vector" ratio="15" rot="R180"/>
 <attribute name="PIE-INT-REF-NUM" value="DIODE" x="13.843" y="24.13" size="1.778" layer="27" rot="R180" display="off"/>
 </element>
-<element name="JP2" library="pie" package="1X03-MTA" value="" x="14.1478" y="13.081" smashed="yes" rot="R180">
-<attribute name="PIE-INT-REF-NUM" value="MTA" x="26.8478" y="1.651" size="1.778" layer="27" rot="R180" display="off"/>
-<attribute name="NAME" x="17.93875" y="15.41145" size="0.762" layer="25" font="vector" ratio="15" rot="R180"/>
-<attribute name="VALUE" x="17.9578" y="17.526" size="1.27" layer="27" font="vector" rot="R180"/>
+<element name="JP2" library="pie" package="1X03-MTA" value="" x="13.8938" y="13.081" smashed="yes" rot="R180">
+<attribute name="PIE-INT-REF-NUM" value="MTA" x="26.5938" y="1.651" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="NAME" x="9.17575" y="14.01445" size="0.635" layer="25" font="vector" ratio="15" rot="R270"/>
+<attribute name="VALUE" x="17.7038" y="17.526" size="1.27" layer="27" font="vector" rot="R180"/>
 </element>
 <element name="SJ2" library="pie" package="SJ_2S-NO" value="SOLDERJUMPERNO" x="4.8514" y="14.478" smashed="yes">
 <attribute name="PIE-INT-REF-NUM" value="DNL" x="-20.5486" y="29.718" size="1.778" layer="27" display="off"/>
@@ -1176,10 +1178,10 @@ design rules under a new name.</description>
 <attribute name="VALUE" x="14.986" y="5.969" size="0.6096" layer="27" font="vector" ratio="15" rot="R180"/>
 <attribute name="PIE-INT-REF-NUM" value="DIODE" x="13.843" y="7.62" size="1.778" layer="27" rot="R180" display="off"/>
 </element>
-<element name="JP3" library="pie" package="1X03-MTA" value="" x="22.098" y="19.685" smashed="yes" rot="R180">
-<attribute name="PIE-INT-REF-NUM" value="MTA" x="34.798" y="8.255" size="1.778" layer="27" rot="R180" display="off"/>
-<attribute name="NAME" x="25.88895" y="22.01545" size="0.762" layer="25" font="vector" ratio="15" rot="R180"/>
-<attribute name="VALUE" x="25.908" y="24.13" size="1.27" layer="27" font="vector" rot="R180"/>
+<element name="JP3" library="pie" package="1X03-MTA" value="" x="21.844" y="19.685" smashed="yes" rot="R180">
+<attribute name="PIE-INT-REF-NUM" value="MTA" x="34.544" y="8.255" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="NAME" x="25.88895" y="20.49145" size="0.635" layer="25" font="vector" ratio="15" rot="R270"/>
+<attribute name="VALUE" x="25.654" y="24.13" size="1.27" layer="27" font="vector" rot="R180"/>
 </element>
 <element name="SJ3" library="pie" package="SJ_2S-NO" value="SOLDERJUMPERNO" x="2.159" y="14.478" smashed="yes">
 <attribute name="PIE-INT-REF-NUM" value="DNL" x="-23.241" y="29.718" size="1.778" layer="27" display="off"/>
@@ -1198,10 +1200,10 @@ design rules under a new name.</description>
 <attribute name="VALUE" x="23.368" y="26.416" size="0.6096" layer="27" font="vector" ratio="15" rot="R180"/>
 <attribute name="PIE-INT-REF-NUM" value="DIODE" x="22.225" y="24.13" size="1.778" layer="27" rot="R180" display="off"/>
 </element>
-<element name="JP4" library="pie" package="1X03-MTA" value="" x="22.098" y="13.081" smashed="yes" rot="R180">
-<attribute name="PIE-INT-REF-NUM" value="MTA" x="34.798" y="1.651" size="1.778" layer="27" rot="R180" display="off"/>
-<attribute name="NAME" x="25.95245" y="15.4432" size="0.762" layer="25" font="vector" ratio="15" rot="R180"/>
-<attribute name="VALUE" x="25.908" y="17.526" size="1.27" layer="27" font="vector" rot="R180"/>
+<element name="JP4" library="pie" package="1X03-MTA" value="" x="21.844" y="13.081" smashed="yes" rot="R180">
+<attribute name="PIE-INT-REF-NUM" value="MTA" x="34.544" y="1.651" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="NAME" x="25.82545" y="13.6652" size="0.635" layer="25" font="vector" ratio="15" rot="R270"/>
+<attribute name="VALUE" x="25.654" y="17.526" size="1.27" layer="27" font="vector" rot="R180"/>
 </element>
 <element name="SJ4" library="pie" package="SJ_2S-NO" value="SOLDERJUMPERNO" x="4.826" y="11.176" smashed="yes">
 <attribute name="PIE-INT-REF-NUM" value="DNL" x="-20.574" y="26.416" size="1.778" layer="27" display="off"/>
@@ -1369,10 +1371,7 @@ design rules under a new name.</description>
 <contactref element="D1" pad="A"/>
 <wire x1="15.843" y1="24.13" x2="15.875" y2="24.13" width="0.2032" layer="1"/>
 <wire x1="15.875" y1="24.13" x2="16.6878" y2="23.3172" width="0.3048" layer="1"/>
-<wire x1="16.6878" y1="23.3172" x2="16.6878" y2="19.685" width="0.3048" layer="1"/>
-<wire x1="16.6878" y1="19.685" x2="16.6878" y2="18.8722" width="0.3048" layer="1"/>
-<wire x1="16.6878" y1="18.8722" x2="17.9832" y2="17.5768" width="0.3048" layer="1"/>
-<wire x1="17.9832" y1="17.5768" x2="17.9832" y2="5.7912" width="0.3048" layer="1"/>
+<wire x1="17.9832" y1="18.1356" x2="17.9832" y2="5.7912" width="0.3048" layer="1"/>
 <wire x1="17.9832" y1="5.7912" x2="17.526" y2="5.334" width="0.3048" layer="1"/>
 <via x="17.526" y="5.334" extent="1-16" drill="0.508"/>
 <via x="13.9065" y="4.76885" extent="1-16" drill="0.508"/>
@@ -1393,6 +1392,9 @@ design rules under a new name.</description>
 <wire x1="6.985" y1="5.842" x2="7.493" y2="5.842" width="0.3048" layer="1"/>
 <wire x1="7.493" y1="5.842" x2="8.89" y2="4.445" width="0.3048" layer="1"/>
 <wire x1="2.5582" y1="10.6498" x2="2.5582" y2="11.176" width="0.3048" layer="1"/>
+<wire x1="16.4338" y1="19.685" x2="16.4338" y2="23.0632" width="0.3048" layer="1"/>
+<wire x1="16.4338" y1="23.0632" x2="16.6878" y2="23.3172" width="0.3048" layer="1"/>
+<wire x1="16.4338" y1="19.685" x2="17.9832" y2="18.1356" width="0.3048" layer="1"/>
 </signal>
 <signal name="N$2">
 <contactref element="Q1" pad="1"/>
@@ -1410,8 +1412,6 @@ design rules under a new name.</description>
 <contactref element="Q2" pad="3"/>
 <contactref element="SJ2" pad="2"/>
 <contactref element="D2" pad="A"/>
-<wire x1="16.6878" y1="13.081" x2="16.6878" y2="8.4648" width="0.3048" layer="1"/>
-<wire x1="16.6878" y1="8.4648" x2="15.843" y2="7.62" width="0.3048" layer="1"/>
 <wire x1="15.843" y1="7.62" x2="15.843" y2="7.271" width="0.2032" layer="1"/>
 <wire x1="15.843" y1="7.271" x2="16.002" y2="7.112" width="0.2032" layer="1"/>
 <wire x1="16.002" y1="7.112" x2="16.002" y2="4.402" width="0.3048" layer="1"/>
@@ -1428,6 +1428,8 @@ design rules under a new name.</description>
 <wire x1="8.89" y1="11.557" x2="9.779" y2="10.668" width="0.3048" layer="1"/>
 <wire x1="9.779" y1="10.668" x2="9.779" y2="7.62" width="0.3048" layer="1"/>
 <wire x1="9.779" y1="7.62" x2="10.16" y2="7.239" width="0.3048" layer="1"/>
+<wire x1="16.4338" y1="13.081" x2="16.4338" y2="8.2108" width="0.3048" layer="1"/>
+<wire x1="16.4338" y1="8.2108" x2="15.843" y2="7.62" width="0.3048" layer="1"/>
 </signal>
 <signal name="N$5">
 <contactref element="Q2" pad="1"/>
@@ -1451,13 +1453,9 @@ design rules under a new name.</description>
 <contactref element="D3" pad="A"/>
 <wire x1="24.225" y1="24.13" x2="24.257" y2="24.13" width="0.2032" layer="1"/>
 <wire x1="24.257" y1="24.13" x2="24.638" y2="23.749" width="0.2032" layer="1"/>
-<wire x1="24.638" y1="23.749" x2="24.638" y2="19.685" width="0.3048" layer="1"/>
 <via x="22.3774" y="4.6228" extent="1-16" drill="0.508"/>
 <via x="25.2984" y="5.6388" extent="1-16" drill="0.508"/>
 <wire x1="25.2984" y1="5.6388" x2="25.3492" y2="5.6388" width="0.2032" layer="1"/>
-<wire x1="25.3492" y1="5.6388" x2="26.7208" y2="7.0104" width="0.3048" layer="1"/>
-<wire x1="26.7208" y1="7.0104" x2="26.7208" y2="17.6022" width="0.3048" layer="1"/>
-<wire x1="26.7208" y1="17.6022" x2="24.638" y2="19.685" width="0.3048" layer="1"/>
 <via x="17.526" y="4.064" extent="1-16" drill="0.508"/>
 <wire x1="22.1361" y1="4.3815" x2="20.3405" y2="4.3815" width="0.3048" layer="1"/>
 <wire x1="20.3405" y1="4.3815" x2="20.32" y2="4.402" width="0.2032" layer="1"/>
@@ -1484,6 +1482,12 @@ design rules under a new name.</description>
 <wire x1="22.1361" y1="4.3815" x2="22.3774" y2="4.6228" width="0.3048" layer="1"/>
 <wire x1="25.2984" y1="5.6388" x2="23.3934" y2="5.6388" width="0.3048" layer="16"/>
 <wire x1="23.3934" y1="5.6388" x2="22.3774" y2="4.6228" width="0.3048" layer="16"/>
+<wire x1="24.384" y1="19.685" x2="24.384" y2="23.971" width="0.3048" layer="1"/>
+<wire x1="24.384" y1="23.971" x2="24.225" y2="24.13" width="0.3048" layer="1"/>
+<wire x1="25.3492" y1="5.6388" x2="25.3492" y2="5.6642" width="0.3048" layer="1"/>
+<wire x1="25.3492" y1="5.6642" x2="26.416" y2="6.731" width="0.3048" layer="1"/>
+<wire x1="26.416" y1="6.731" x2="26.416" y2="17.653" width="0.3048" layer="1"/>
+<wire x1="26.416" y1="17.653" x2="24.384" y2="19.685" width="0.3048" layer="1"/>
 </signal>
 <signal name="N$8">
 <contactref element="Q3" pad="1"/>
@@ -1499,8 +1503,6 @@ design rules under a new name.</description>
 <contactref element="Q4" pad="3"/>
 <contactref element="SJ4" pad="2"/>
 <contactref element="D4" pad="A"/>
-<wire x1="24.638" y1="13.081" x2="24.638" y2="8.033" width="0.3048" layer="1"/>
-<wire x1="24.638" y1="8.033" x2="24.225" y2="7.62" width="0.2032" layer="1"/>
 <wire x1="24.225" y1="7.62" x2="24.257" y2="7.62" width="0.2032" layer="1"/>
 <wire x1="24.257" y1="7.62" x2="24.511" y2="7.366" width="0.2032" layer="1"/>
 <wire x1="24.511" y1="7.366" x2="24.511" y2="4.402" width="0.3048" layer="1"/>
@@ -1516,6 +1518,9 @@ design rules under a new name.</description>
 <wire x1="8.255" y1="11.43" x2="9.271" y2="10.414" width="0.3048" layer="1"/>
 <wire x1="9.271" y1="10.414" x2="9.271" y2="6.4135" width="0.3048" layer="1"/>
 <wire x1="9.271" y1="6.4135" x2="9.5885" y2="6.096" width="0.3048" layer="1"/>
+<wire x1="24.384" y1="13.081" x2="24.384" y2="8.509" width="0.3048" layer="1"/>
+<wire x1="24.384" y1="8.509" x2="24.225" y2="8.35" width="0.3048" layer="1"/>
+<wire x1="24.225" y1="8.35" x2="24.225" y2="7.62" width="0.3048" layer="1"/>
 </signal>
 <signal name="N$11">
 <contactref element="Q4" pad="1"/>
@@ -1703,28 +1708,14 @@ design rules under a new name.</description>
 <signal name="VOUT">
 <contactref element="JP1" pad="2"/>
 <contactref element="D1" pad="C"/>
-<wire x1="14.1478" y1="23.4442" x2="13.462" y2="24.13" width="0.3048" layer="1"/>
-<wire x1="13.462" y1="24.13" x2="11.843" y2="24.13" width="0.3048" layer="1"/>
-<wire x1="14.1478" y1="23.4442" x2="14.1478" y2="19.685" width="0.3048" layer="1"/>
 <contactref element="JP2" pad="2"/>
 <contactref element="D2" pad="C"/>
-<wire x1="14.1478" y1="13.081" x2="14.1478" y2="9.9248" width="0.3048" layer="1"/>
-<wire x1="14.1478" y1="9.9248" x2="11.843" y2="7.62" width="0.3048" layer="1"/>
 <contactref element="JP3" pad="2"/>
 <contactref element="D3" pad="C"/>
 <wire x1="20.225" y1="24.13" x2="21.082" y2="24.13" width="0.3048" layer="1"/>
-<wire x1="22.098" y1="23.622" x2="22.098" y2="19.685" width="0.3048" layer="1"/>
-<wire x1="22.098" y1="23.622" x2="21.59" y2="24.13" width="0.3048" layer="1"/>
-<wire x1="21.59" y1="24.13" x2="20.225" y2="24.13" width="0.3048" layer="1"/>
-<wire x1="14.1478" y1="20.955" x2="14.5288" y2="21.336" width="0.3048" layer="16"/>
-<wire x1="14.5288" y1="21.336" x2="21.59" y2="21.336" width="0.3048" layer="16"/>
-<wire x1="21.59" y1="21.336" x2="22.098" y2="20.828" width="0.3048" layer="16"/>
-<wire x1="22.098" y1="20.828" x2="22.098" y2="19.685" width="0.3048" layer="16"/>
 <contactref element="JP4" pad="2"/>
 <contactref element="D4" pad="C"/>
 <wire x1="20.225" y1="7.62" x2="20.225" y2="7.652" width="0.3048" layer="1"/>
-<wire x1="20.225" y1="7.652" x2="22.098" y2="9.525" width="0.3048" layer="1"/>
-<wire x1="22.098" y1="9.525" x2="22.098" y2="13.081" width="0.3048" layer="1"/>
 <contactref element="SJ5" pad="2"/>
 <polygon width="0.4064" layer="16">
 <vertex x="0" y="0"/>
@@ -1746,6 +1737,17 @@ design rules under a new name.</description>
 <wire x1="30.099" y1="7.112" x2="29.972" y2="6.985" width="0.254" layer="1"/>
 <wire x1="31.2746" y1="10.668" x2="30.099" y2="10.668" width="0.254" layer="1"/>
 <wire x1="30.099" y1="10.668" x2="29.972" y2="10.795" width="0.254" layer="1"/>
+<wire x1="13.8938" y1="19.685" x2="13.8938" y2="22.0792" width="0.3048" layer="1"/>
+<wire x1="13.8938" y1="22.0792" x2="11.843" y2="24.13" width="0.3048" layer="1"/>
+<wire x1="21.844" y1="19.685" x2="21.844" y2="22.511" width="0.3048" layer="1"/>
+<wire x1="21.844" y1="22.511" x2="20.225" y2="24.13" width="0.3048" layer="1"/>
+<wire x1="13.8938" y1="19.685" x2="13.8938" y2="13.081" width="0.3048" layer="1"/>
+<wire x1="21.844" y1="13.081" x2="21.844" y2="19.685" width="0.3048" layer="1"/>
+<wire x1="20.225" y1="7.652" x2="20.32" y2="7.652" width="0.3048" layer="1"/>
+<wire x1="20.32" y1="7.652" x2="20.32" y2="11.557" width="0.3048" layer="1"/>
+<wire x1="21.844" y1="13.081" x2="20.32" y2="11.557" width="0.3048" layer="1"/>
+<wire x1="11.843" y1="7.62" x2="11.843" y2="11.0302" width="0.3048" layer="1"/>
+<wire x1="11.843" y1="11.0302" x2="13.8938" y2="13.081" width="0.3048" layer="1"/>
 </signal>
 <signal name="IO6">
 <contactref element="JP5" pad="3"/>

--- a/eda/smartsensorPowered.sch
+++ b/eda/smartsensorPowered.sch
@@ -4513,8 +4513,8 @@ In this library the device names are the same as the pin names of the symbols, t
 <instance part="SUPPLY3" gate="GND" x="152.4" y="134.62" smashed="yes">
 <attribute name="VALUE" x="150.495" y="131.445" size="1.27" layer="96" font="vector"/>
 </instance>
-<instance part="SUPPLY1" gate="GND" x="139.7" y="86.36" smashed="yes">
-<attribute name="VALUE" x="137.795" y="83.185" size="1.27" layer="96" font="vector"/>
+<instance part="SUPPLY1" gate="GND" x="139.7" y="81.28" smashed="yes">
+<attribute name="VALUE" x="137.795" y="78.105" size="1.27" layer="96" font="vector"/>
 </instance>
 <instance part="SUPPLY2" gate="GND" x="152.4" y="147.32" smashed="yes">
 <attribute name="VALUE" x="150.495" y="144.145" size="1.27" layer="96" font="vector"/>
@@ -4671,6 +4671,7 @@ In this library the device names are the same as the pin names of the symbols, t
 <segment>
 <pinref part="SUPPLY1" gate="GND" pin="GND"/>
 <pinref part="CIN" gate="G$1" pin="2"/>
+<wire x1="139.7" y1="83.82" x2="139.7" y2="88.9" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="SUPPLY3" gate="GND" pin="GND"/>

--- a/eda/smartsensorPowered.sch
+++ b/eda/smartsensorPowered.sch
@@ -4359,7 +4359,7 @@ In this library the device names are the same as the pin names of the symbols, t
 <parts>
 <part name="FRAME1" library="pie" deviceset="FRAME-LETTER" device="">
 <attribute name="AUTHOR" value="Vincent D, Devin H, Kate R, Andrew H, Sumita G, Tobin H, Casey D."/>
-<attribute name="REVISION" value="4B"/>
+<attribute name="REVISION" value="4C"/>
 </part>
 <part name="SUPPLY10" library="pie" deviceset="GND" device=""/>
 <part name="Q1" library="pie" deviceset="MOSFET-NCHANNEL" device="SMD" value="IRFML8244"/>
@@ -4439,11 +4439,11 @@ In this library the device names are the same as the pin names of the symbols, t
 <instance part="SUPPLY10" gate="GND" x="78.74" y="134.62"/>
 <instance part="Q1" gate="G$1" x="66.294" y="144.272" smashed="yes">
 <attribute name="NAME" x="62.992" y="148.082" size="1.778" layer="95" font="vector"/>
-<attribute name="VALUE" x="54.356" y="139.192" size="1.778" layer="96" font="vector"/>
+<attribute name="VALUE" x="51.308" y="138.938" size="1.778" layer="96" font="vector"/>
 </instance>
 <instance part="D4" gate="G$1" x="72.898" y="72.39" smashed="yes" rot="R270">
-<attribute name="NAME" x="77.9526" y="72.644" size="1.778" layer="95" font="vector" rot="R180"/>
-<attribute name="VALUE" x="70.5866" y="69.85" size="1.778" layer="96" font="vector" rot="R270"/>
+<attribute name="NAME" x="77.9526" y="74.168" size="1.778" layer="95" font="vector" rot="R180"/>
+<attribute name="VALUE" x="73.3806" y="74.676" size="1.778" layer="96" font="vector"/>
 </instance>
 <instance part="JP1" gate="G$1" x="86.36" y="142.24" rot="R180"/>
 <instance part="SJ1" gate="1" x="52.832" y="150.622" smashed="yes">
@@ -4457,11 +4457,11 @@ In this library the device names are the same as the pin names of the symbols, t
 <instance part="SUPPLY7" gate="GND" x="78.74" y="109.22"/>
 <instance part="Q2" gate="G$1" x="66.294" y="118.872" smashed="yes">
 <attribute name="NAME" x="62.992" y="122.682" size="1.778" layer="95" font="vector"/>
-<attribute name="VALUE" x="36.576" y="113.792" size="1.778" layer="96" font="vector"/>
+<attribute name="VALUE" x="52.07" y="113.792" size="1.778" layer="96" font="vector"/>
 </instance>
 <instance part="D1" gate="G$1" x="72.898" y="146.304" smashed="yes" rot="R270">
-<attribute name="NAME" x="77.9526" y="146.558" size="1.778" layer="95" font="vector" rot="R180"/>
-<attribute name="VALUE" x="70.5866" y="143.764" size="1.778" layer="96" font="vector" rot="R270"/>
+<attribute name="NAME" x="77.9526" y="148.082" size="1.778" layer="95" font="vector" rot="R180"/>
+<attribute name="VALUE" x="73.3806" y="148.336" size="1.778" layer="96" font="vector"/>
 </instance>
 <instance part="JP2" gate="G$1" x="86.36" y="116.84" rot="R180"/>
 <instance part="SJ2" gate="1" x="52.832" y="125.222" smashed="yes">
@@ -4475,11 +4475,11 @@ In this library the device names are the same as the pin names of the symbols, t
 <instance part="SUPPLY8" gate="GND" x="78.74" y="86.36"/>
 <instance part="Q3" gate="G$1" x="66.294" y="96.012" smashed="yes">
 <attribute name="NAME" x="62.992" y="99.822" size="1.778" layer="95" font="vector"/>
-<attribute name="VALUE" x="36.576" y="90.932" size="1.778" layer="96" font="vector"/>
+<attribute name="VALUE" x="52.07" y="90.678" size="1.778" layer="96" font="vector"/>
 </instance>
 <instance part="D2" gate="G$1" x="72.898" y="120.65" smashed="yes" rot="R270">
-<attribute name="NAME" x="77.9526" y="120.904" size="1.778" layer="95" font="vector" rot="R180"/>
-<attribute name="VALUE" x="70.5866" y="118.11" size="1.778" layer="96" font="vector" rot="R270"/>
+<attribute name="NAME" x="77.6986" y="122.174" size="1.778" layer="95" font="vector" rot="R180"/>
+<attribute name="VALUE" x="73.8886" y="122.682" size="1.778" layer="96" font="vector"/>
 </instance>
 <instance part="JP3" gate="G$1" x="88.9" y="93.98" rot="R180"/>
 <instance part="SJ3" gate="1" x="52.832" y="102.362" smashed="yes">
@@ -4493,13 +4493,13 @@ In this library the device names are the same as the pin names of the symbols, t
 <instance part="SUPPLY9" gate="GND" x="78.74" y="60.96"/>
 <instance part="Q4" gate="G$1" x="66.294" y="70.612" smashed="yes">
 <attribute name="NAME" x="62.992" y="74.422" size="1.778" layer="95" font="vector"/>
-<attribute name="VALUE" x="36.576" y="65.532" size="1.778" layer="96" font="vector"/>
+<attribute name="VALUE" x="51.562" y="65.532" size="1.778" layer="96" font="vector"/>
 </instance>
 <instance part="D3" gate="G$1" x="72.898" y="97.79" smashed="yes" rot="R270">
 <attribute name="NAME" x="77.9526" y="98.044" size="1.778" layer="95" font="vector" rot="R180"/>
 <attribute name="VALUE" x="73.406" y="99.2886" size="1.778" layer="96" font="vector"/>
 </instance>
-<instance part="JP4" gate="G$1" x="86.36" y="68.58" rot="R180"/>
+<instance part="JP4" gate="G$1" x="88.9" y="68.58" rot="R180"/>
 <instance part="SJ4" gate="1" x="52.832" y="76.962" smashed="yes">
 <attribute name="NAME" x="50.546" y="73.406" size="1.778" layer="95" font="vector"/>
 <attribute name="VALUE" x="43.18" y="78.74" size="1.778" layer="96" font="vector"/>
@@ -4635,12 +4635,12 @@ In this library the device names are the same as the pin names of the symbols, t
 <segment>
 <pinref part="JP4" gate="G$1" pin="3"/>
 <pinref part="SUPPLY9" gate="GND" pin="GND"/>
-<wire x1="78.74" y1="66.04" x2="78.74" y2="64.77" width="0.1524" layer="91"/>
+<wire x1="81.28" y1="66.04" x2="81.28" y2="64.77" width="0.1524" layer="91"/>
 <pinref part="Q4" gate="G$1" pin="S"/>
-<wire x1="78.74" y1="64.77" x2="78.74" y2="63.5" width="0.1524" layer="91"/>
+<wire x1="81.28" y1="64.77" x2="78.74" y2="63.5" width="0.1524" layer="91"/>
 <wire x1="66.294" y1="65.532" x2="66.294" y2="64.77" width="0.1524" layer="91"/>
-<wire x1="66.294" y1="64.77" x2="78.74" y2="64.77" width="0.1524" layer="91"/>
-<junction x="78.74" y="64.77"/>
+<wire x1="66.294" y1="64.77" x2="81.28" y2="64.77" width="0.1524" layer="91"/>
+<junction x="81.28" y="64.77"/>
 </segment>
 <segment>
 <pinref part="SUPPLY11" gate="GND" pin="GND"/>
@@ -4768,12 +4768,12 @@ In this library the device names are the same as the pin names of the symbols, t
 <net name="6V_IF_SERVO4" class="0">
 <segment>
 <pinref part="JP4" gate="G$1" pin="1"/>
-<wire x1="78.74" y1="71.12" x2="78.74" y2="76.962" width="0.1524" layer="91"/>
+<wire x1="81.28" y1="71.12" x2="81.28" y2="76.962" width="0.1524" layer="91"/>
 <pinref part="Q4" gate="G$1" pin="D"/>
 <wire x1="66.294" y1="75.692" x2="66.294" y2="76.962" width="0.1524" layer="91"/>
 <wire x1="66.294" y1="76.962" x2="72.898" y2="76.962" width="0.1524" layer="91"/>
 <pinref part="SJ4" gate="1" pin="2"/>
-<wire x1="72.898" y1="76.962" x2="78.74" y2="76.962" width="0.1524" layer="91"/>
+<wire x1="72.898" y1="76.962" x2="81.28" y2="76.962" width="0.1524" layer="91"/>
 <wire x1="57.912" y1="76.962" x2="66.294" y2="76.962" width="0.1524" layer="91"/>
 <junction x="66.294" y="76.962"/>
 <pinref part="D4" gate="G$1" pin="A"/>
@@ -4920,7 +4920,7 @@ In this library the device names are the same as the pin names of the symbols, t
 <segment>
 <pinref part="JP4" gate="G$1" pin="2"/>
 <label x="78.486" y="68.326" size="1.778" layer="95" font="vector" rot="R180"/>
-<wire x1="78.74" y1="68.58" x2="72.898" y2="68.58" width="0.1524" layer="91"/>
+<wire x1="81.28" y1="68.58" x2="72.898" y2="68.58" width="0.1524" layer="91"/>
 <pinref part="D4" gate="G$1" pin="C"/>
 <wire x1="72.898" y1="69.85" x2="72.898" y2="68.58" width="0.1524" layer="91"/>
 </segment>

--- a/eda/smartsensorPowered.sch
+++ b/eda/smartsensorPowered.sch
@@ -4358,9 +4358,8 @@ In this library the device names are the same as the pin names of the symbols, t
 </classes>
 <parts>
 <part name="FRAME1" library="pie" deviceset="FRAME-LETTER" device="">
-<attribute name="AUTHOR" value="Vincent D, Devin H, Kate R,
-Andrew H, Sumita G, Tobin H, Casey D."/>
-<attribute name="REVISION" value="4A"/>
+<attribute name="AUTHOR" value="Vincent D, Devin H, Kate R, Andrew H, Sumita G, Tobin H, Casey D."/>
+<attribute name="REVISION" value="4B"/>
 </part>
 <part name="SUPPLY10" library="pie" deviceset="GND" device=""/>
 <part name="Q1" library="pie" deviceset="MOSFET-NCHANNEL" device="SMD" value="IRFML8244"/>
@@ -5020,6 +5019,14 @@ Andrew H, Sumita G, Tobin H, Casey D."/>
 </nets>
 </sheet>
 </sheets>
+<errors>
+<approved hash="113,1,81.9573,140.521,JP1,,,,,"/>
+<approved hash="113,1,81.9573,115.121,JP2,,,,,"/>
+<approved hash="113,1,84.4973,92.2613,JP3,,,,,"/>
+<approved hash="113,1,81.9573,66.8613,JP4,,,,,"/>
+<approved hash="113,1,172.957,58.8687,JP5,,,,,"/>
+<approved hash="113,1,193.277,58.8687,JP6,,,,,"/>
+</errors>
 </schematic>
 </drawing>
 </eagle>

--- a/eda/smartsensorPowered.sch
+++ b/eda/smartsensorPowered.sch
@@ -4359,7 +4359,7 @@ In this library the device names are the same as the pin names of the symbols, t
 <parts>
 <part name="FRAME1" library="pie" deviceset="FRAME-LETTER" device="">
 <attribute name="AUTHOR" value="Vincent D, Devin H, Kate R, Andrew H, Sumita G, Tobin H, Casey D."/>
-<attribute name="REVISION" value="4C"/>
+<attribute name="REVISION" value="4B"/>
 </part>
 <part name="SUPPLY10" library="pie" deviceset="GND" device=""/>
 <part name="Q1" library="pie" deviceset="MOSFET-NCHANNEL" device="SMD" value="IRFML8244"/>
@@ -4472,7 +4472,7 @@ In this library the device names are the same as the pin names of the symbols, t
 <attribute name="NAME" x="46.736" y="119.3546" size="1.778" layer="95" font="vector"/>
 <attribute name="VALUE" x="54.864" y="119.38" size="1.778" layer="96" font="vector"/>
 </instance>
-<instance part="SUPPLY8" gate="GND" x="78.74" y="86.36"/>
+<instance part="SUPPLY8" gate="GND" x="81.28" y="87.63"/>
 <instance part="Q3" gate="G$1" x="66.294" y="96.012" smashed="yes">
 <attribute name="NAME" x="62.992" y="99.822" size="1.778" layer="95" font="vector"/>
 <attribute name="VALUE" x="52.07" y="90.678" size="1.778" layer="96" font="vector"/>
@@ -4490,7 +4490,7 @@ In this library the device names are the same as the pin names of the symbols, t
 <attribute name="NAME" x="46.736" y="96.4946" size="1.778" layer="95" font="vector"/>
 <attribute name="VALUE" x="54.864" y="96.52" size="1.778" layer="96" font="vector"/>
 </instance>
-<instance part="SUPPLY9" gate="GND" x="78.74" y="60.96"/>
+<instance part="SUPPLY9" gate="GND" x="81.28" y="60.96"/>
 <instance part="Q4" gate="G$1" x="66.294" y="70.612" smashed="yes">
 <attribute name="NAME" x="62.992" y="74.422" size="1.778" layer="95" font="vector"/>
 <attribute name="VALUE" x="51.562" y="65.532" size="1.778" layer="96" font="vector"/>
@@ -4625,19 +4625,17 @@ In this library the device names are the same as the pin names of the symbols, t
 <pinref part="JP3" gate="G$1" pin="3"/>
 <pinref part="SUPPLY8" gate="GND" pin="GND"/>
 <pinref part="Q3" gate="G$1" pin="S"/>
-<wire x1="78.74" y1="90.17" x2="78.74" y2="88.9" width="0.1524" layer="91"/>
 <wire x1="66.294" y1="90.932" x2="66.294" y2="90.17" width="0.1524" layer="91"/>
-<wire x1="66.294" y1="90.17" x2="78.74" y2="90.17" width="0.1524" layer="91"/>
-<wire x1="81.28" y1="91.44" x2="78.74" y2="91.44" width="0.1524" layer="91"/>
-<wire x1="78.74" y1="91.44" x2="78.74" y2="88.9" width="0.1524" layer="91"/>
-<junction x="78.74" y="88.9"/>
+<wire x1="66.294" y1="90.17" x2="81.28" y2="90.17" width="0.1524" layer="91"/>
+<wire x1="81.28" y1="91.44" x2="81.28" y2="90.17" width="0.1524" layer="91"/>
+<junction x="81.28" y="90.17"/>
 </segment>
 <segment>
 <pinref part="JP4" gate="G$1" pin="3"/>
 <pinref part="SUPPLY9" gate="GND" pin="GND"/>
 <wire x1="81.28" y1="66.04" x2="81.28" y2="64.77" width="0.1524" layer="91"/>
 <pinref part="Q4" gate="G$1" pin="S"/>
-<wire x1="81.28" y1="64.77" x2="78.74" y2="63.5" width="0.1524" layer="91"/>
+<wire x1="81.28" y1="64.77" x2="81.28" y2="63.5" width="0.1524" layer="91"/>
 <wire x1="66.294" y1="65.532" x2="66.294" y2="64.77" width="0.1524" layer="91"/>
 <wire x1="66.294" y1="64.77" x2="81.28" y2="64.77" width="0.1524" layer="91"/>
 <junction x="81.28" y="64.77"/>

--- a/eda/smartsensorPowered.sch
+++ b/eda/smartsensorPowered.sch
@@ -4696,7 +4696,7 @@ In this library the device names are the same as the pin names of the symbols, t
 <pinref part="SUPPLY14" gate="GND" pin="GND"/>
 </segment>
 </net>
-<net name="N$1" class="0">
+<net name="6V_IF_SERVO1" class="0">
 <segment>
 <pinref part="JP1" gate="G$1" pin="1"/>
 <wire x1="78.74" y1="144.78" x2="78.74" y2="150.622" width="0.1524" layer="91"/>
@@ -4719,7 +4719,7 @@ In this library the device names are the same as the pin names of the symbols, t
 <wire x1="58.674" y1="144.272" x2="57.404" y2="144.272" width="0.1524" layer="91"/>
 </segment>
 </net>
-<net name="N$4" class="0">
+<net name="6V_IF_SERVO2" class="0">
 <segment>
 <pinref part="JP2" gate="G$1" pin="1"/>
 <wire x1="78.74" y1="119.38" x2="78.74" y2="125.222" width="0.1524" layer="91"/>
@@ -4742,7 +4742,7 @@ In this library the device names are the same as the pin names of the symbols, t
 <wire x1="58.674" y1="118.872" x2="57.404" y2="118.872" width="0.1524" layer="91"/>
 </segment>
 </net>
-<net name="N$7" class="0">
+<net name="6V_IF_SERVO3" class="0">
 <segment>
 <pinref part="JP3" gate="G$1" pin="1"/>
 <wire x1="81.28" y1="96.52" x2="81.28" y2="102.362" width="0.1524" layer="91"/>
@@ -4765,7 +4765,7 @@ In this library the device names are the same as the pin names of the symbols, t
 <wire x1="58.674" y1="96.012" x2="57.404" y2="96.012" width="0.1524" layer="91"/>
 </segment>
 </net>
-<net name="N$10" class="0">
+<net name="6V_IF_SERVO4" class="0">
 <segment>
 <pinref part="JP4" gate="G$1" pin="1"/>
 <wire x1="78.74" y1="71.12" x2="78.74" y2="76.962" width="0.1524" layer="91"/>


### PR DESCRIPTION
- shifted the silkscreen for the four MTA output connectors such that they
  are visible on the board
- put a GND polarity marking using a dot
- Shifted MTA output connectors and traces slightly
- Changed the revision from 'A' to 'B'
- Updated the revision date to 2 Oct 2015