### PR TITLE
Woodstock Rev C

### DIFF
--- a/eda/cape.brd
+++ b/eda/cape.brd
@@ -32,8 +32,8 @@
 <layer number="36" name="bGlue" color="7" fill="5" visible="yes" active="yes"/>
 <layer number="37" name="tTest" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="38" name="bTest" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="39" name="tKeepout" color="4" fill="11" visible="no" active="yes"/>
-<layer number="40" name="bKeepout" color="1" fill="11" visible="no" active="yes"/>
+<layer number="39" name="tKeepout" color="4" fill="11" visible="yes" active="yes"/>
+<layer number="40" name="bKeepout" color="1" fill="11" visible="yes" active="yes"/>
 <layer number="41" name="tRestrict" color="4" fill="10" visible="yes" active="yes"/>
 <layer number="42" name="bRestrict" color="1" fill="10" visible="yes" active="yes"/>
 <layer number="43" name="vRestrict" color="2" fill="10" visible="yes" active="yes"/>
@@ -224,8 +224,8 @@ Horizontal</description>
 <pad name="GND" x="0" y="-2.159" drill="2.2" diameter="2.794" shape="long" rot="R180"/>
 <pad name="VCC" x="0" y="2.159" drill="2.2" diameter="2.794" shape="long" rot="R180"/>
 <hole x="5.588" y="0" drill="4.445"/>
-<text x="3.175" y="2.54" size="1.27" layer="27" rot="R180" align="top-right">&gt;VALUE</text>
-<text x="3.175" y="-2.54" size="1.27" layer="25" rot="R180" align="bottom-right">&gt;NAME</text>
+<text x="3.175" y="2.54" size="1.27" layer="27" font="vector" rot="R180" align="top-right">&gt;VALUE</text>
+<text x="3.175" y="-2.54" size="1.27" layer="25" font="vector" rot="R180" align="bottom-right">&gt;NAME</text>
 <rectangle x1="-0.254" y1="-2.413" x2="0.254" y2="-1.905" layer="51" rot="R90"/>
 <rectangle x1="-0.254" y1="1.905" x2="0.254" y2="2.413" layer="51" rot="R90"/>
 <wire x1="-1.905" y1="-4.064" x2="1.905" y2="-4.064" width="0.254" layer="21"/>

--- a/eda/cape.brd
+++ b/eda/cape.brd
@@ -32,8 +32,8 @@
 <layer number="36" name="bGlue" color="7" fill="5" visible="yes" active="yes"/>
 <layer number="37" name="tTest" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="38" name="bTest" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="39" name="tKeepout" color="4" fill="11" visible="yes" active="yes"/>
-<layer number="40" name="bKeepout" color="1" fill="11" visible="yes" active="yes"/>
+<layer number="39" name="tKeepout" color="4" fill="11" visible="no" active="yes"/>
+<layer number="40" name="bKeepout" color="1" fill="11" visible="no" active="yes"/>
 <layer number="41" name="tRestrict" color="4" fill="10" visible="yes" active="yes"/>
 <layer number="42" name="bRestrict" color="1" fill="10" visible="yes" active="yes"/>
 <layer number="43" name="vRestrict" color="2" fill="10" visible="yes" active="yes"/>
@@ -44,8 +44,8 @@
 <layer number="48" name="Document" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="49" name="Reference" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="50" name="dxf" color="7" fill="1" visible="no" active="no"/>
-<layer number="51" name="tDocu" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="52" name="bDocu" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="51" name="tDocu" color="14" fill="1" visible="yes" active="yes"/>
+<layer number="52" name="bDocu" color="6" fill="1" visible="yes" active="yes"/>
 <layer number="53" name="tGND_GNDA" color="7" fill="9" visible="no" active="no"/>
 <layer number="54" name="bGND_GNDA" color="1" fill="9" visible="no" active="no"/>
 <layer number="56" name="wert" color="7" fill="1" visible="no" active="no"/>
@@ -140,36 +140,39 @@
 <board>
 <plain>
 <wire x1="0" y1="0" x2="72.06" y2="0" width="0.254" layer="20"/>
-<wire x1="72.06" y1="0" x2="72.06" y2="54.6" width="0.254" layer="20"/>
-<wire x1="72.06" y1="54.6" x2="0" y2="54.6" width="0.254" layer="20"/>
-<wire x1="0" y1="54.6" x2="0" y2="0" width="0.254" layer="20"/>
-<text x="44.45" y="46.99" size="1.4224" layer="21" font="vector" ratio="15" align="top-center">Pioneers in Engineering
-Woodstock
-Version 1 Rev. B</text>
-<text x="44.45" y="13.97" size="0.889" layer="21" font="vector" ratio="15" align="top-center">(c) Pioneers in Engineering.
+<wire x1="72.06" y1="0" x2="72.06" y2="54.61" width="0.254" layer="20"/>
+<wire x1="72.06" y1="54.61" x2="0" y2="54.61" width="0.254" layer="20"/>
+<wire x1="0" y1="54.61" x2="0" y2="39.37" width="0.254" layer="20"/>
+<text x="43.18" y="47.879" size="1.4224" layer="21" font="vector" ratio="15" align="top-center">Pioneers in Engineering</text>
+<text x="43.18" y="13.208" size="0.889" layer="21" font="vector" ratio="15" align="top-center">(c) Pioneers in Engineering.
 Design by: Casey Duckering
 This design is open source hardware.
 For more information, visit
 pioneers.berkeley.edu/opensource.</text>
 <text x="7.62" y="10.16" size="1.27" layer="27" font="vector" ratio="15" align="bottom-right">12V</text>
 <text x="7.62" y="15.24" size="1.27" layer="27" font="vector" ratio="15" align="top-right">GND</text>
-<text x="71.12" y="17.78" size="0.9144" layer="1" font="vector" ratio="20" rot="R90" align="bottom-center">v1  revB
-5 Nov 2015</text>
-<hole x="1.524" y="20.701" drill="1.905"/>
-<hole x="3.81" y="20.701" drill="1.905"/>
-<hole x="6.096" y="20.701" drill="1.905"/>
-<hole x="8.382" y="20.701" drill="1.905"/>
-<hole x="8.382" y="27.432" drill="1.905"/>
-<hole x="8.382" y="25.146" drill="1.905"/>
-<hole x="8.382" y="22.86" drill="1.905"/>
-<hole x="8.382" y="29.591" drill="1.905"/>
-<hole x="8.382" y="36.322" drill="1.905"/>
-<hole x="8.382" y="34.036" drill="1.905"/>
-<hole x="8.382" y="31.75" drill="1.905"/>
-<hole x="1.524" y="38.481" drill="1.905"/>
-<hole x="3.81" y="38.481" drill="1.905"/>
-<hole x="6.096" y="38.481" drill="1.905"/>
-<hole x="8.382" y="38.481" drill="1.905"/>
+<text x="71.12" y="17.78" size="0.9144" layer="1" font="vector" ratio="20" rot="R90" align="bottom-center">v1  revC
+24 Nov 2015</text>
+<hole x="1.143" y="21.844" drill="1.905"/>
+<hole x="3.429" y="21.844" drill="1.905"/>
+<hole x="5.715" y="21.844" drill="1.905"/>
+<hole x="8.001" y="21.844" drill="1.905"/>
+<hole x="8.001" y="28.702" drill="1.905"/>
+<hole x="8.001" y="26.416" drill="1.905"/>
+<hole x="8.001" y="24.13" drill="1.905"/>
+<hole x="8.001" y="30.988" drill="1.905"/>
+<hole x="8.001" y="35.56" drill="1.905"/>
+<hole x="8.001" y="33.274" drill="1.905"/>
+<hole x="1.143" y="37.846" drill="1.905"/>
+<hole x="3.429" y="37.846" drill="1.905"/>
+<hole x="5.715" y="37.846" drill="1.905"/>
+<hole x="8.001" y="37.846" drill="1.905"/>
+<wire x1="0" y1="20.32" x2="0" y2="0" width="0.254" layer="20"/>
+<wire x1="0" y1="20.32" x2="9.525" y2="20.32" width="0.254" layer="20"/>
+<wire x1="9.525" y1="20.32" x2="9.525" y2="39.37" width="0.254" layer="20"/>
+<wire x1="9.525" y1="39.37" x2="0" y2="39.37" width="0.254" layer="20"/>
+<text x="43.18" y="45.212" size="2.286" layer="21" font="vector" ratio="15" align="top-center">Woodstock</text>
+<text x="43.18" y="41.783" size="1.016" layer="21" font="vector" ratio="15" align="top-center">Version 1 Rev. C</text>
 </plain>
 <libraries>
 <library name="pie">
@@ -218,57 +221,42 @@ Horizontal</description>
 </package>
 <package name="POWER-WIRE">
 <description>A connection for a pair of power and ground wires to solder directly to a board with a strain relief hole.</description>
-<pad name="GND" x="-1.27" y="0" drill="1.1" shape="square"/>
-<pad name="VCC" x="1.27" y="0" drill="1.1"/>
-<hole x="0" y="-3.81" drill="4.445"/>
-<text x="4.445" y="1.27" size="1.27" layer="27" rot="R90" align="bottom-right">&gt;VALUE</text>
-<text x="-3.175" y="1.27" size="1.27" layer="25" rot="R90" align="bottom-right">&gt;NAME</text>
-<wire x1="-2.54" y1="0.635" x2="-1.905" y2="1.27" width="0.127" layer="51"/>
-<wire x1="-1.905" y1="1.27" x2="-0.635" y2="1.27" width="0.127" layer="51"/>
-<wire x1="-0.635" y1="1.27" x2="0" y2="0.635" width="0.127" layer="51"/>
-<wire x1="0" y1="0.635" x2="0.635" y2="1.27" width="0.127" layer="51"/>
-<wire x1="0.635" y1="1.27" x2="1.905" y2="1.27" width="0.127" layer="51"/>
-<wire x1="1.905" y1="1.27" x2="2.54" y2="0.635" width="0.127" layer="51"/>
-<wire x1="2.54" y1="0.635" x2="2.54" y2="-0.635" width="0.127" layer="51"/>
-<wire x1="2.54" y1="-0.635" x2="1.905" y2="-1.27" width="0.127" layer="51"/>
-<wire x1="1.905" y1="-1.27" x2="0.635" y2="-1.27" width="0.127" layer="51"/>
-<wire x1="0.635" y1="-1.27" x2="0" y2="-0.635" width="0.127" layer="51"/>
-<wire x1="0" y1="-0.635" x2="-0.635" y2="-1.27" width="0.127" layer="51"/>
-<wire x1="-0.635" y1="-1.27" x2="-1.905" y2="-1.27" width="0.127" layer="51"/>
-<wire x1="-1.905" y1="-1.27" x2="-2.54" y2="-0.635" width="0.127" layer="51"/>
-<wire x1="-2.54" y1="-0.635" x2="-2.54" y2="0.635" width="0.127" layer="51"/>
-<wire x1="-2.54" y1="0.635" x2="-1.905" y2="1.27" width="0.127" layer="21"/>
-<wire x1="-1.905" y1="1.27" x2="-0.635" y2="1.27" width="0.127" layer="21"/>
-<wire x1="-0.635" y1="1.27" x2="0" y2="0.635" width="0.127" layer="21"/>
-<wire x1="0" y1="0.635" x2="0.635" y2="1.27" width="0.127" layer="21"/>
-<wire x1="0.635" y1="1.27" x2="1.905" y2="1.27" width="0.127" layer="21"/>
-<wire x1="1.905" y1="1.27" x2="2.54" y2="0.635" width="0.127" layer="21"/>
-<wire x1="2.54" y1="0.635" x2="2.54" y2="-0.635" width="0.127" layer="21"/>
-<wire x1="2.54" y1="-0.635" x2="1.905" y2="-1.27" width="0.127" layer="21"/>
-<wire x1="1.905" y1="-1.27" x2="0.635" y2="-1.27" width="0.127" layer="21"/>
-<wire x1="0.635" y1="-1.27" x2="0" y2="-0.635" width="0.127" layer="21"/>
-<wire x1="0" y1="-0.635" x2="-0.635" y2="-1.27" width="0.127" layer="21"/>
-<wire x1="-0.635" y1="-1.27" x2="-1.905" y2="-1.27" width="0.127" layer="21"/>
-<wire x1="-1.905" y1="-1.27" x2="-2.54" y2="-0.635" width="0.127" layer="21"/>
-<wire x1="-2.54" y1="-0.635" x2="-2.54" y2="0.635" width="0.127" layer="21"/>
-<wire x1="-2.54" y1="0.635" x2="-1.905" y2="1.27" width="0.127" layer="22"/>
-<wire x1="-1.905" y1="1.27" x2="-0.635" y2="1.27" width="0.127" layer="22"/>
-<wire x1="-0.635" y1="1.27" x2="0" y2="0.635" width="0.127" layer="22"/>
-<wire x1="0" y1="0.635" x2="0.635" y2="1.27" width="0.127" layer="22"/>
-<wire x1="0.635" y1="1.27" x2="1.905" y2="1.27" width="0.127" layer="22"/>
-<wire x1="1.905" y1="1.27" x2="2.54" y2="0.635" width="0.127" layer="22"/>
-<wire x1="2.54" y1="0.635" x2="2.54" y2="-0.635" width="0.127" layer="22"/>
-<wire x1="2.54" y1="-0.635" x2="1.905" y2="-1.27" width="0.127" layer="22"/>
-<wire x1="1.905" y1="-1.27" x2="0.635" y2="-1.27" width="0.127" layer="22"/>
-<wire x1="0.635" y1="-1.27" x2="0" y2="-0.635" width="0.127" layer="22"/>
-<wire x1="0" y1="-0.635" x2="-0.635" y2="-1.27" width="0.127" layer="22"/>
-<wire x1="-0.635" y1="-1.27" x2="-1.905" y2="-1.27" width="0.127" layer="22"/>
-<wire x1="-1.905" y1="-1.27" x2="-2.54" y2="-0.635" width="0.127" layer="22"/>
-<wire x1="-2.54" y1="-0.635" x2="-2.54" y2="0.635" width="0.127" layer="22"/>
-<rectangle x1="-2.54" y1="-6.35" x2="2.54" y2="1.27" layer="39"/>
-<rectangle x1="-2.54" y1="-6.35" x2="2.54" y2="1.27" layer="40"/>
-<rectangle x1="-1.524" y1="-0.254" x2="-1.016" y2="0.254" layer="51"/>
-<rectangle x1="1.016" y1="-0.254" x2="1.524" y2="0.254" layer="51"/>
+<pad name="GND" x="0" y="-2.159" drill="2.2" diameter="2.794" shape="long" rot="R180"/>
+<pad name="VCC" x="0" y="2.159" drill="2.2" diameter="2.794" shape="long" rot="R180"/>
+<hole x="5.588" y="0" drill="4.445"/>
+<text x="3.175" y="2.54" size="1.27" layer="27" rot="R180" align="top-right">&gt;VALUE</text>
+<text x="3.175" y="-2.54" size="1.27" layer="25" rot="R180" align="bottom-right">&gt;NAME</text>
+<rectangle x1="-0.254" y1="-2.413" x2="0.254" y2="-1.905" layer="51" rot="R90"/>
+<rectangle x1="-0.254" y1="1.905" x2="0.254" y2="2.413" layer="51" rot="R90"/>
+<wire x1="-1.905" y1="-4.064" x2="1.905" y2="-4.064" width="0.254" layer="21"/>
+<wire x1="-1.016" y1="4.064" x2="-0.762" y2="4.064" width="0.254" layer="21"/>
+<wire x1="-0.127" y1="4.064" x2="0.127" y2="4.064" width="0.254" layer="21"/>
+<wire x1="0.762" y1="4.064" x2="1.016" y2="4.064" width="0.254" layer="21"/>
+<rectangle x1="3.81" y1="-1.905" x2="13.97" y2="1.905" layer="51"/>
+<wire x1="5.715" y1="0.381" x2="0" y2="2.159" width="1.524" layer="51"/>
+<wire x1="0" y1="-2.159" x2="5.715" y2="-0.381" width="1.524" layer="51"/>
+<wire x1="-1.905" y1="4.064" x2="-1.651" y2="4.064" width="0.254" layer="21"/>
+<wire x1="1.651" y1="4.064" x2="1.905" y2="4.064" width="0.254" layer="21"/>
+<polygon width="0" layer="39">
+<vertex x="-3.175" y="3.81"/>
+<vertex x="3.175" y="3.81"/>
+<vertex x="4.445" y="2.54"/>
+<vertex x="8.255" y="2.54"/>
+<vertex x="8.255" y="-2.54"/>
+<vertex x="4.445" y="-2.54"/>
+<vertex x="3.175" y="-3.81"/>
+<vertex x="-3.175" y="-3.81"/>
+</polygon>
+<polygon width="0" layer="40">
+<vertex x="-3.175" y="3.81"/>
+<vertex x="3.175" y="3.81"/>
+<vertex x="4.445" y="2.54"/>
+<vertex x="8.255" y="2.54"/>
+<vertex x="8.255" y="-2.54"/>
+<vertex x="4.445" y="-2.54"/>
+<vertex x="3.175" y="-3.81"/>
+<vertex x="-3.175" y="-3.81"/>
+</polygon>
 </package>
 <package name="TO-220">
 <description>&lt;b&gt;VOLTAGE REGULATOR&lt;/b&gt;</description>
@@ -1169,28 +1157,28 @@ design rules under a new name.</description>
 <attribute name="PIE-INT-REF-NUM" value="Anderson" x="9.906" y="12.7" size="1.778" layer="27" display="off"/>
 <attribute name="NAME" x="9.906" y="12.7" size="1.27" layer="25" font="vector" ratio="15" align="center"/>
 </element>
-<element name="J2" library="pie" package="POWER-WIRE" value="12V" x="63.5" y="27.94" smashed="yes" rot="R90">
-<attribute name="VALUE" x="69.85" y="27.94" size="1.27" layer="27" font="vector" ratio="15" rot="R270" align="bottom-center"/>
+<element name="J2" library="pie" package="POWER-WIRE" value="12V" x="62.23" y="32.385" smashed="yes">
+<attribute name="VALUE" x="67.818" y="34.925" size="1.27" layer="27" font="vector" ratio="15" rot="R180" align="top-center"/>
 </element>
-<element name="J3" library="pie" package="POWER-WIRE" value="5V" x="63.5" y="34.29" smashed="yes" rot="R90">
-<attribute name="VALUE" x="69.85" y="34.29" size="1.27" layer="27" font="vector" ratio="15" rot="R270" align="bottom-center"/>
+<element name="J3" library="pie" package="POWER-WIRE" value="5V" x="62.23" y="41.91" smashed="yes">
+<attribute name="VALUE" x="67.818" y="44.45" size="1.27" layer="27" font="vector" ratio="15" align="bottom-center"/>
 </element>
 <element name="CAPE" library="SparkFun-Boards" package="BEAGLE_BONE_BLACK_CAPE" value="BEAGLE_BONE_BLACK_CAPE" x="-11.43" y="0" smashed="yes"/>
 <element name="VREG" library="pie" package="TO-220" value="LT323A" x="19.05" y="25.4" smashed="yes">
 <attribute name="NAME" x="12.319" y="21.082" size="1.27" layer="25" font="vector" ratio="15" rot="R90"/>
-<attribute name="VALUE" x="28.067" y="27.94" size="1.27" layer="27" font="vector" ratio="15" rot="R90"/>
+<attribute name="VALUE" x="12.319" y="31.75" size="1.27" layer="27" font="vector" ratio="15" rot="R270" align="top-center"/>
 </element>
-<element name="U$3" library="pie" package="OSHW-LOGO-M" value="" x="62.484" y="10.541"/>
-<element name="U$6" library="pie" package="PIE-LOGO" value="" x="45.72" y="28.448"/>
+<element name="U$3" library="pie" package="OSHW-LOGO-M" value="" x="62.484" y="10.16"/>
+<element name="U$6" library="pie" package="PIE-LOGO" value="" x="43.18" y="27.051"/>
 <element name="R1" library="pie" package="R0603" value="130" x="10.16" y="45.72" smashed="yes">
 <attribute name="PIE-INT-REF-NUM" value="RESISTOR-GENERIC" x="10.16" y="52.07" size="1.778" layer="27" display="off"/>
 <attribute name="NAME" x="8.89" y="46.99" size="1.27" layer="25" font="vector" ratio="15"/>
 <attribute name="VALUE" x="8.89" y="43.18" size="1.27" layer="27" font="vector" ratio="15"/>
 </element>
-<element name="ON" library="pie" package="LED-0805" value="RED" x="5.08" y="45.72" smashed="yes" rot="R180">
+<element name="ON" library="pie" package="LED-0805" value="YELLOW" x="5.08" y="45.72" smashed="yes" rot="R180">
 <attribute name="PIE-INT-REF-NUM" value="LED" x="5.08" y="52.07" size="1.778" layer="27" rot="R180" display="off"/>
-<attribute name="NAME" x="6.985" y="44.45" size="1.27" layer="25" font="vector" ratio="15" rot="R180"/>
-<attribute name="VALUE" x="6.985" y="48.26" size="1.27" layer="25" font="vector" ratio="15" rot="R180"/>
+<attribute name="NAME" x="7.239" y="44.45" size="1.27" layer="25" font="vector" ratio="15" rot="R180"/>
+<attribute name="VALUE" x="7.747" y="48.26" size="1.27" layer="25" font="vector" ratio="15" rot="R180"/>
 </element>
 </elements>
 <signals>
@@ -1245,7 +1233,6 @@ design rules under a new name.</description>
 <contactref element="VREG" pad="IN"/>
 <contactref element="J2" pad="VCC"/>
 <wire x1="16.51" y1="16.51" x2="16.51" y2="15.367" width="1.524" layer="1"/>
-<wire x1="63.5" y1="29.21" x2="60.96" y2="29.21" width="1.524" layer="16"/>
 <wire x1="10.287" y1="9.144" x2="16.51" y2="15.367" width="1.524" layer="1"/>
 <wire x1="11.938" y1="8.89" x2="10.033" y2="8.89" width="0.6096" layer="16"/>
 <contactref element="BATT" pad="PIN2-LEAD"/>
@@ -1253,11 +1240,12 @@ design rules under a new name.</description>
 <wire x1="10.287" y1="8.89" x2="10.287" y2="9.144" width="0.6096" layer="1"/>
 <wire x1="10.287" y1="8.89" x2="10.033" y2="8.89" width="0.6096" layer="1"/>
 <wire x1="10.033" y1="8.89" x2="9.906" y2="8.763" width="0.6096" layer="1"/>
-<wire x1="9.906" y1="8.763" x2="40.513" y2="8.763" width="1.524" layer="16"/>
-<wire x1="40.513" y1="8.763" x2="60.96" y2="29.21" width="1.524" layer="16"/>
+<wire x1="9.906" y1="8.763" x2="27.94" y2="8.763" width="1.524" layer="16"/>
 <contactref element="C1" pad="A"/>
 <wire x1="9.906" y1="8.763" x2="21.587" y2="8.763" width="0.508" layer="1"/>
 <wire x1="21.587" y1="8.763" x2="21.587" y2="8.89" width="0.508" layer="1"/>
+<wire x1="62.23" y1="34.544" x2="53.721" y2="34.544" width="1.524" layer="16"/>
+<wire x1="53.721" y1="34.544" x2="27.94" y2="8.763" width="1.524" layer="16"/>
 <wire x1="4.572" y1="8.763" x2="9.906" y2="8.763" width="0" layer="19" extent="1-16"/>
 </signal>
 <signal name="N$1">

--- a/eda/cape.sch
+++ b/eda/cape.sch
@@ -247,8 +247,8 @@ Vertical</description>
 <pad name="GND" x="0" y="-2.159" drill="2.2" diameter="2.794" shape="long" rot="R180"/>
 <pad name="VCC" x="0" y="2.159" drill="2.2" diameter="2.794" shape="long" rot="R180"/>
 <hole x="5.588" y="0" drill="4.445"/>
-<text x="3.175" y="2.54" size="1.27" layer="27" rot="R180" align="top-right">&gt;VALUE</text>
-<text x="3.175" y="-2.54" size="1.27" layer="25" rot="R180" align="bottom-right">&gt;NAME</text>
+<text x="3.175" y="2.54" size="1.27" layer="27" font="vector" rot="R180" align="top-right">&gt;VALUE</text>
+<text x="3.175" y="-2.54" size="1.27" layer="25" font="vector" rot="R180" align="bottom-right">&gt;NAME</text>
 <rectangle x1="-0.254" y1="-2.413" x2="0.254" y2="-1.905" layer="51" rot="R90"/>
 <rectangle x1="-0.254" y1="1.905" x2="0.254" y2="2.413" layer="51" rot="R90"/>
 <wire x1="-1.905" y1="-4.064" x2="1.905" y2="-4.064" width="0.254" layer="21"/>

--- a/eda/cape.sch
+++ b/eda/cape.sch
@@ -14,14 +14,14 @@
 <layer number="18" name="Vias" color="2" fill="1" visible="no" active="no"/>
 <layer number="19" name="Unrouted" color="6" fill="1" visible="no" active="no"/>
 <layer number="20" name="Dimension" color="15" fill="1" visible="no" active="no"/>
-<layer number="21" name="tPlace" color="16" fill="1" visible="no" active="no"/>
-<layer number="22" name="bPlace" color="17" fill="1" visible="no" active="no"/>
+<layer number="21" name="tPlace" color="7" fill="1" visible="no" active="no"/>
+<layer number="22" name="bPlace" color="7" fill="1" visible="no" active="no"/>
 <layer number="23" name="tOrigins" color="15" fill="1" visible="no" active="no"/>
 <layer number="24" name="bOrigins" color="15" fill="1" visible="no" active="no"/>
-<layer number="25" name="tNames" color="18" fill="1" visible="no" active="no"/>
-<layer number="26" name="bNames" color="19" fill="1" visible="no" active="no"/>
-<layer number="27" name="tValues" color="18" fill="1" visible="no" active="no"/>
-<layer number="28" name="bValues" color="19" fill="1" visible="no" active="no"/>
+<layer number="25" name="tNames" color="7" fill="1" visible="no" active="no"/>
+<layer number="26" name="bNames" color="7" fill="1" visible="no" active="no"/>
+<layer number="27" name="tValues" color="7" fill="1" visible="no" active="no"/>
+<layer number="28" name="bValues" color="7" fill="1" visible="no" active="no"/>
 <layer number="29" name="tStop" color="7" fill="3" visible="no" active="no"/>
 <layer number="30" name="bStop" color="7" fill="6" visible="no" active="no"/>
 <layer number="31" name="tCream" color="7" fill="4" visible="no" active="no"/>
@@ -44,8 +44,8 @@
 <layer number="48" name="Document" color="7" fill="1" visible="no" active="no"/>
 <layer number="49" name="Reference" color="7" fill="1" visible="no" active="no"/>
 <layer number="50" name="dxf" color="7" fill="1" visible="no" active="no"/>
-<layer number="51" name="tDocu" color="6" fill="1" visible="no" active="no"/>
-<layer number="52" name="bDocu" color="6" fill="1" visible="no" active="no"/>
+<layer number="51" name="tDocu" color="7" fill="1" visible="no" active="no"/>
+<layer number="52" name="bDocu" color="7" fill="1" visible="no" active="no"/>
 <layer number="53" name="tGND_GNDA" color="7" fill="9" visible="no" active="no"/>
 <layer number="54" name="bGND_GNDA" color="1" fill="9" visible="no" active="no"/>
 <layer number="56" name="wert" color="7" fill="1" visible="no" active="no"/>
@@ -244,57 +244,42 @@ Vertical</description>
 </package>
 <package name="POWER-WIRE">
 <description>A connection for a pair of power and ground wires to solder directly to a board with a strain relief hole.</description>
-<pad name="GND" x="-1.27" y="0" drill="1.1" shape="square"/>
-<pad name="VCC" x="1.27" y="0" drill="1.1"/>
-<hole x="0" y="-3.81" drill="4.445"/>
-<text x="4.445" y="1.27" size="1.27" layer="27" rot="R90" align="bottom-right">&gt;VALUE</text>
-<text x="-3.175" y="1.27" size="1.27" layer="25" rot="R90" align="bottom-right">&gt;NAME</text>
-<wire x1="-2.54" y1="0.635" x2="-1.905" y2="1.27" width="0.127" layer="51"/>
-<wire x1="-1.905" y1="1.27" x2="-0.635" y2="1.27" width="0.127" layer="51"/>
-<wire x1="-0.635" y1="1.27" x2="0" y2="0.635" width="0.127" layer="51"/>
-<wire x1="0" y1="0.635" x2="0.635" y2="1.27" width="0.127" layer="51"/>
-<wire x1="0.635" y1="1.27" x2="1.905" y2="1.27" width="0.127" layer="51"/>
-<wire x1="1.905" y1="1.27" x2="2.54" y2="0.635" width="0.127" layer="51"/>
-<wire x1="2.54" y1="0.635" x2="2.54" y2="-0.635" width="0.127" layer="51"/>
-<wire x1="2.54" y1="-0.635" x2="1.905" y2="-1.27" width="0.127" layer="51"/>
-<wire x1="1.905" y1="-1.27" x2="0.635" y2="-1.27" width="0.127" layer="51"/>
-<wire x1="0.635" y1="-1.27" x2="0" y2="-0.635" width="0.127" layer="51"/>
-<wire x1="0" y1="-0.635" x2="-0.635" y2="-1.27" width="0.127" layer="51"/>
-<wire x1="-0.635" y1="-1.27" x2="-1.905" y2="-1.27" width="0.127" layer="51"/>
-<wire x1="-1.905" y1="-1.27" x2="-2.54" y2="-0.635" width="0.127" layer="51"/>
-<wire x1="-2.54" y1="-0.635" x2="-2.54" y2="0.635" width="0.127" layer="51"/>
-<wire x1="-2.54" y1="0.635" x2="-1.905" y2="1.27" width="0.127" layer="21"/>
-<wire x1="-1.905" y1="1.27" x2="-0.635" y2="1.27" width="0.127" layer="21"/>
-<wire x1="-0.635" y1="1.27" x2="0" y2="0.635" width="0.127" layer="21"/>
-<wire x1="0" y1="0.635" x2="0.635" y2="1.27" width="0.127" layer="21"/>
-<wire x1="0.635" y1="1.27" x2="1.905" y2="1.27" width="0.127" layer="21"/>
-<wire x1="1.905" y1="1.27" x2="2.54" y2="0.635" width="0.127" layer="21"/>
-<wire x1="2.54" y1="0.635" x2="2.54" y2="-0.635" width="0.127" layer="21"/>
-<wire x1="2.54" y1="-0.635" x2="1.905" y2="-1.27" width="0.127" layer="21"/>
-<wire x1="1.905" y1="-1.27" x2="0.635" y2="-1.27" width="0.127" layer="21"/>
-<wire x1="0.635" y1="-1.27" x2="0" y2="-0.635" width="0.127" layer="21"/>
-<wire x1="0" y1="-0.635" x2="-0.635" y2="-1.27" width="0.127" layer="21"/>
-<wire x1="-0.635" y1="-1.27" x2="-1.905" y2="-1.27" width="0.127" layer="21"/>
-<wire x1="-1.905" y1="-1.27" x2="-2.54" y2="-0.635" width="0.127" layer="21"/>
-<wire x1="-2.54" y1="-0.635" x2="-2.54" y2="0.635" width="0.127" layer="21"/>
-<wire x1="-2.54" y1="0.635" x2="-1.905" y2="1.27" width="0.127" layer="22"/>
-<wire x1="-1.905" y1="1.27" x2="-0.635" y2="1.27" width="0.127" layer="22"/>
-<wire x1="-0.635" y1="1.27" x2="0" y2="0.635" width="0.127" layer="22"/>
-<wire x1="0" y1="0.635" x2="0.635" y2="1.27" width="0.127" layer="22"/>
-<wire x1="0.635" y1="1.27" x2="1.905" y2="1.27" width="0.127" layer="22"/>
-<wire x1="1.905" y1="1.27" x2="2.54" y2="0.635" width="0.127" layer="22"/>
-<wire x1="2.54" y1="0.635" x2="2.54" y2="-0.635" width="0.127" layer="22"/>
-<wire x1="2.54" y1="-0.635" x2="1.905" y2="-1.27" width="0.127" layer="22"/>
-<wire x1="1.905" y1="-1.27" x2="0.635" y2="-1.27" width="0.127" layer="22"/>
-<wire x1="0.635" y1="-1.27" x2="0" y2="-0.635" width="0.127" layer="22"/>
-<wire x1="0" y1="-0.635" x2="-0.635" y2="-1.27" width="0.127" layer="22"/>
-<wire x1="-0.635" y1="-1.27" x2="-1.905" y2="-1.27" width="0.127" layer="22"/>
-<wire x1="-1.905" y1="-1.27" x2="-2.54" y2="-0.635" width="0.127" layer="22"/>
-<wire x1="-2.54" y1="-0.635" x2="-2.54" y2="0.635" width="0.127" layer="22"/>
-<rectangle x1="-2.54" y1="-6.35" x2="2.54" y2="1.27" layer="39"/>
-<rectangle x1="-2.54" y1="-6.35" x2="2.54" y2="1.27" layer="40"/>
-<rectangle x1="-1.524" y1="-0.254" x2="-1.016" y2="0.254" layer="51"/>
-<rectangle x1="1.016" y1="-0.254" x2="1.524" y2="0.254" layer="51"/>
+<pad name="GND" x="0" y="-2.159" drill="2.2" diameter="2.794" shape="long" rot="R180"/>
+<pad name="VCC" x="0" y="2.159" drill="2.2" diameter="2.794" shape="long" rot="R180"/>
+<hole x="5.588" y="0" drill="4.445"/>
+<text x="3.175" y="2.54" size="1.27" layer="27" rot="R180" align="top-right">&gt;VALUE</text>
+<text x="3.175" y="-2.54" size="1.27" layer="25" rot="R180" align="bottom-right">&gt;NAME</text>
+<rectangle x1="-0.254" y1="-2.413" x2="0.254" y2="-1.905" layer="51" rot="R90"/>
+<rectangle x1="-0.254" y1="1.905" x2="0.254" y2="2.413" layer="51" rot="R90"/>
+<wire x1="-1.905" y1="-4.064" x2="1.905" y2="-4.064" width="0.254" layer="21"/>
+<wire x1="-1.016" y1="4.064" x2="-0.762" y2="4.064" width="0.254" layer="21"/>
+<wire x1="-0.127" y1="4.064" x2="0.127" y2="4.064" width="0.254" layer="21"/>
+<wire x1="0.762" y1="4.064" x2="1.016" y2="4.064" width="0.254" layer="21"/>
+<rectangle x1="3.81" y1="-1.905" x2="13.97" y2="1.905" layer="51"/>
+<wire x1="5.715" y1="0.381" x2="0" y2="2.159" width="1.524" layer="51"/>
+<wire x1="0" y1="-2.159" x2="5.715" y2="-0.381" width="1.524" layer="51"/>
+<wire x1="-1.905" y1="4.064" x2="-1.651" y2="4.064" width="0.254" layer="21"/>
+<wire x1="1.651" y1="4.064" x2="1.905" y2="4.064" width="0.254" layer="21"/>
+<polygon width="0" layer="39">
+<vertex x="-3.175" y="3.81"/>
+<vertex x="3.175" y="3.81"/>
+<vertex x="4.445" y="2.54"/>
+<vertex x="8.255" y="2.54"/>
+<vertex x="8.255" y="-2.54"/>
+<vertex x="4.445" y="-2.54"/>
+<vertex x="3.175" y="-3.81"/>
+<vertex x="-3.175" y="-3.81"/>
+</polygon>
+<polygon width="0" layer="40">
+<vertex x="-3.175" y="3.81"/>
+<vertex x="3.175" y="3.81"/>
+<vertex x="4.445" y="2.54"/>
+<vertex x="8.255" y="2.54"/>
+<vertex x="8.255" y="-2.54"/>
+<vertex x="4.445" y="-2.54"/>
+<vertex x="3.175" y="-3.81"/>
+<vertex x="-3.175" y="-3.81"/>
+</polygon>
 </package>
 <package name="R0402">
 <description>&lt;b&gt;RESISTOR&lt;/b&gt;</description>
@@ -4484,7 +4469,7 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <part name="BATT" library="pie" deviceset="ANDERSON" device="HORIZONTAL" value="12V"/>
 <part name="FRAME1" library="pie" deviceset="FRAME-LETTER" device="">
 <attribute name="AUTHOR" value="Casey Duckering"/>
-<attribute name="REVISION" value="1B"/>
+<attribute name="REVISION" value="1C"/>
 </part>
 <part name="C1" library="pie" deviceset="CAP_POL" device="1206" value="2.2 uF TANT"/>
 <part name="C2" library="pie" deviceset="CAP_POL" device="1206" value="2.2 uF TANT"/>
@@ -4499,7 +4484,7 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <part name="J2" library="pie" deviceset="POWER-WIRE" device="" value="12V"/>
 <part name="J3" library="pie" deviceset="POWER-WIRE" device="" value="5V"/>
 <part name="R1" library="pie" deviceset="R-US_" device="R0603" value="130"/>
-<part name="ON" library="pie" deviceset="LED" device="0805" value="RED"/>
+<part name="ON" library="pie" deviceset="LED" device="0805" value="YELLOW"/>
 <part name="SUPPLY12" library="pie" deviceset="GND" device=""/>
 <part name="U$7" library="pie" deviceset="5V" device=""/>
 <part name="SUPPLY4" library="pie" deviceset="GND" device=""/>

--- a/eda/pie.lbr
+++ b/eda/pie.lbr
@@ -3,10 +3,10 @@
 <eagle version="7.4.0">
 <drawing>
 <settings>
-<setting alwaysvectorfont="yes"/>
+<setting alwaysvectorfont="no"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<grid distance="0.05" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.025" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="1" fill="3" visible="no" active="no"/>
@@ -9187,8 +9187,8 @@ Vertical</description>
 <pad name="GND" x="0" y="-2.159" drill="2.2" diameter="2.794" shape="long" rot="R180"/>
 <pad name="VCC" x="0" y="2.159" drill="2.2" diameter="2.794" shape="long" rot="R180"/>
 <hole x="5.588" y="0" drill="4.445"/>
-<text x="3.175" y="2.54" size="1.27" layer="27" rot="R180" align="top-right">&gt;VALUE</text>
-<text x="3.175" y="-2.54" size="1.27" layer="25" rot="R180" align="bottom-right">&gt;NAME</text>
+<text x="3.175" y="2.54" size="1.27" layer="27" font="vector" rot="R180" align="top-right">&gt;VALUE</text>
+<text x="3.175" y="-2.54" size="1.27" layer="25" font="vector" rot="R180" align="bottom-right">&gt;NAME</text>
 <rectangle x1="-0.254" y1="-2.413" x2="0.254" y2="-1.905" layer="51" rot="R90"/>
 <rectangle x1="-0.254" y1="1.905" x2="0.254" y2="2.413" layer="51" rot="R90"/>
 <wire x1="-1.905" y1="-4.064" x2="1.905" y2="-4.064" width="0.254" layer="21"/>

--- a/eda/pie.lbr
+++ b/eda/pie.lbr
@@ -9184,57 +9184,42 @@ Vertical</description>
 </package>
 <package name="POWER-WIRE">
 <description>A connection for a pair of power and ground wires to solder directly to a board with a strain relief hole.</description>
-<pad name="GND" x="-1.27" y="0" drill="1.1" shape="square"/>
-<pad name="VCC" x="1.27" y="0" drill="1.1"/>
-<hole x="0" y="-3.81" drill="4.445"/>
-<text x="4.445" y="1.27" size="1.27" layer="27" rot="R90" align="bottom-right">&gt;VALUE</text>
-<text x="-3.175" y="1.27" size="1.27" layer="25" rot="R90" align="bottom-right">&gt;NAME</text>
-<wire x1="-2.54" y1="0.635" x2="-1.905" y2="1.27" width="0.127" layer="51"/>
-<wire x1="-1.905" y1="1.27" x2="-0.635" y2="1.27" width="0.127" layer="51"/>
-<wire x1="-0.635" y1="1.27" x2="0" y2="0.635" width="0.127" layer="51"/>
-<wire x1="0" y1="0.635" x2="0.635" y2="1.27" width="0.127" layer="51"/>
-<wire x1="0.635" y1="1.27" x2="1.905" y2="1.27" width="0.127" layer="51"/>
-<wire x1="1.905" y1="1.27" x2="2.54" y2="0.635" width="0.127" layer="51"/>
-<wire x1="2.54" y1="0.635" x2="2.54" y2="-0.635" width="0.127" layer="51"/>
-<wire x1="2.54" y1="-0.635" x2="1.905" y2="-1.27" width="0.127" layer="51"/>
-<wire x1="1.905" y1="-1.27" x2="0.635" y2="-1.27" width="0.127" layer="51"/>
-<wire x1="0.635" y1="-1.27" x2="0" y2="-0.635" width="0.127" layer="51"/>
-<wire x1="0" y1="-0.635" x2="-0.635" y2="-1.27" width="0.127" layer="51"/>
-<wire x1="-0.635" y1="-1.27" x2="-1.905" y2="-1.27" width="0.127" layer="51"/>
-<wire x1="-1.905" y1="-1.27" x2="-2.54" y2="-0.635" width="0.127" layer="51"/>
-<wire x1="-2.54" y1="-0.635" x2="-2.54" y2="0.635" width="0.127" layer="51"/>
-<wire x1="-2.54" y1="0.635" x2="-1.905" y2="1.27" width="0.127" layer="21"/>
-<wire x1="-1.905" y1="1.27" x2="-0.635" y2="1.27" width="0.127" layer="21"/>
-<wire x1="-0.635" y1="1.27" x2="0" y2="0.635" width="0.127" layer="21"/>
-<wire x1="0" y1="0.635" x2="0.635" y2="1.27" width="0.127" layer="21"/>
-<wire x1="0.635" y1="1.27" x2="1.905" y2="1.27" width="0.127" layer="21"/>
-<wire x1="1.905" y1="1.27" x2="2.54" y2="0.635" width="0.127" layer="21"/>
-<wire x1="2.54" y1="0.635" x2="2.54" y2="-0.635" width="0.127" layer="21"/>
-<wire x1="2.54" y1="-0.635" x2="1.905" y2="-1.27" width="0.127" layer="21"/>
-<wire x1="1.905" y1="-1.27" x2="0.635" y2="-1.27" width="0.127" layer="21"/>
-<wire x1="0.635" y1="-1.27" x2="0" y2="-0.635" width="0.127" layer="21"/>
-<wire x1="0" y1="-0.635" x2="-0.635" y2="-1.27" width="0.127" layer="21"/>
-<wire x1="-0.635" y1="-1.27" x2="-1.905" y2="-1.27" width="0.127" layer="21"/>
-<wire x1="-1.905" y1="-1.27" x2="-2.54" y2="-0.635" width="0.127" layer="21"/>
-<wire x1="-2.54" y1="-0.635" x2="-2.54" y2="0.635" width="0.127" layer="21"/>
-<wire x1="-2.54" y1="0.635" x2="-1.905" y2="1.27" width="0.127" layer="22"/>
-<wire x1="-1.905" y1="1.27" x2="-0.635" y2="1.27" width="0.127" layer="22"/>
-<wire x1="-0.635" y1="1.27" x2="0" y2="0.635" width="0.127" layer="22"/>
-<wire x1="0" y1="0.635" x2="0.635" y2="1.27" width="0.127" layer="22"/>
-<wire x1="0.635" y1="1.27" x2="1.905" y2="1.27" width="0.127" layer="22"/>
-<wire x1="1.905" y1="1.27" x2="2.54" y2="0.635" width="0.127" layer="22"/>
-<wire x1="2.54" y1="0.635" x2="2.54" y2="-0.635" width="0.127" layer="22"/>
-<wire x1="2.54" y1="-0.635" x2="1.905" y2="-1.27" width="0.127" layer="22"/>
-<wire x1="1.905" y1="-1.27" x2="0.635" y2="-1.27" width="0.127" layer="22"/>
-<wire x1="0.635" y1="-1.27" x2="0" y2="-0.635" width="0.127" layer="22"/>
-<wire x1="0" y1="-0.635" x2="-0.635" y2="-1.27" width="0.127" layer="22"/>
-<wire x1="-0.635" y1="-1.27" x2="-1.905" y2="-1.27" width="0.127" layer="22"/>
-<wire x1="-1.905" y1="-1.27" x2="-2.54" y2="-0.635" width="0.127" layer="22"/>
-<wire x1="-2.54" y1="-0.635" x2="-2.54" y2="0.635" width="0.127" layer="22"/>
-<rectangle x1="-2.54" y1="-6.35" x2="2.54" y2="1.27" layer="39"/>
-<rectangle x1="-2.54" y1="-6.35" x2="2.54" y2="1.27" layer="40"/>
-<rectangle x1="-1.524" y1="-0.254" x2="-1.016" y2="0.254" layer="51"/>
-<rectangle x1="1.016" y1="-0.254" x2="1.524" y2="0.254" layer="51"/>
+<pad name="GND" x="0" y="-2.159" drill="2.2" diameter="2.794" shape="long" rot="R180"/>
+<pad name="VCC" x="0" y="2.159" drill="2.2" diameter="2.794" shape="long" rot="R180"/>
+<hole x="5.588" y="0" drill="4.445"/>
+<text x="3.175" y="2.54" size="1.27" layer="27" rot="R180" align="top-right">&gt;VALUE</text>
+<text x="3.175" y="-2.54" size="1.27" layer="25" rot="R180" align="bottom-right">&gt;NAME</text>
+<rectangle x1="-0.254" y1="-2.413" x2="0.254" y2="-1.905" layer="51" rot="R90"/>
+<rectangle x1="-0.254" y1="1.905" x2="0.254" y2="2.413" layer="51" rot="R90"/>
+<wire x1="-1.905" y1="-4.064" x2="1.905" y2="-4.064" width="0.254" layer="21"/>
+<wire x1="-1.016" y1="4.064" x2="-0.762" y2="4.064" width="0.254" layer="21"/>
+<wire x1="-0.127" y1="4.064" x2="0.127" y2="4.064" width="0.254" layer="21"/>
+<wire x1="0.762" y1="4.064" x2="1.016" y2="4.064" width="0.254" layer="21"/>
+<rectangle x1="3.81" y1="-1.905" x2="13.97" y2="1.905" layer="51"/>
+<wire x1="5.715" y1="0.381" x2="0" y2="2.159" width="1.524" layer="51"/>
+<wire x1="0" y1="-2.159" x2="5.715" y2="-0.381" width="1.524" layer="51"/>
+<wire x1="-1.905" y1="4.064" x2="-1.651" y2="4.064" width="0.254" layer="21"/>
+<wire x1="1.651" y1="4.064" x2="1.905" y2="4.064" width="0.254" layer="21"/>
+<polygon width="0" layer="39">
+<vertex x="-3.175" y="3.81"/>
+<vertex x="3.175" y="3.81"/>
+<vertex x="4.445" y="2.54"/>
+<vertex x="8.255" y="2.54"/>
+<vertex x="8.255" y="-2.54"/>
+<vertex x="4.445" y="-2.54"/>
+<vertex x="3.175" y="-3.81"/>
+<vertex x="-3.175" y="-3.81"/>
+</polygon>
+<polygon width="0" layer="40">
+<vertex x="-3.175" y="3.81"/>
+<vertex x="3.175" y="3.81"/>
+<vertex x="4.445" y="2.54"/>
+<vertex x="8.255" y="2.54"/>
+<vertex x="8.255" y="-2.54"/>
+<vertex x="4.445" y="-2.54"/>
+<vertex x="3.175" y="-3.81"/>
+<vertex x="-3.175" y="-3.81"/>
+</polygon>
 </package>
 <package name="1X03-JMP-OPTION">
 <description>A 3 pin header with silk screen indicating jumper positions to select an option.</description>


### PR DESCRIPTION
- Update revision info
- Make the power connector holes bigger to fit the actual wires
- Change color or power LED to yellow to be more consistent with power LEDs on
  Grizzly and powered smartsensor
- Change the board dimensions to go around the ethernet cutout.  Hopefully Bay
  Area Circuits will cut the board to this shape.  I left the perforation holes
  for now for the case where it is not routed.